### PR TITLE
project: Add Tagging feature.

### DIFF
--- a/app/controllers/TagApp.java
+++ b/app/controllers/TagApp.java
@@ -1,0 +1,48 @@
+package controllers;
+
+import com.avaje.ebean.ExpressionList;
+import models.Project;
+import models.Tag;
+import models.enumeration.Operation;
+import play.mvc.Controller;
+import play.mvc.Result;
+import utils.AccessControl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static play.libs.Json.toJson;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: nori
+ * Date: 13. 4. 12
+ * Time: 오후 3:37
+ * To change this template use File | Settings | File Templates.
+ */
+public class TagApp extends Controller {
+    private static final int MAX_FETCH_TAGS = 1000;
+
+    public static Result tags(String query) {
+        if (!request().accepts("application/json")) {
+            return status(406);
+        }
+
+        ExpressionList<Tag> el = Tag.find.where().contains("name", query);
+        int total = el.findRowCount();
+        if (total > MAX_FETCH_TAGS) {
+            el.setMaxRows(MAX_FETCH_TAGS);
+            response().setHeader("Content-Range", "items " + MAX_FETCH_TAGS + "/" + total);
+        }
+
+        Map<Long, String> tags = new HashMap<Long, String>();
+        for (Tag tag: el.findList()) {
+            tags.put(tag.id, tag.name);
+        }
+
+        return ok(toJson(tags));
+    }
+
+}

--- a/app/models/Tag.java
+++ b/app/models/Tag.java
@@ -1,0 +1,71 @@
+package models;
+
+import models.enumeration.ResourceType;
+import models.resource.Resource;
+import play.data.validation.Constraints.Required;
+import play.db.ebean.Model;
+
+import javax.persistence.*;
+import java.util.List;
+import java.util.Set;
+
+@Entity
+public class Tag extends Model {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = -35487506476718498L;
+    public static Finder<Long, Tag> find = new Finder<Long, Tag>(Long.class, Tag.class);
+
+    @Id
+    public Long id;
+
+    @Required
+    @Column(unique=true)
+    public String name;
+
+    @ManyToMany(mappedBy="tags")
+    public Set<Project> projects;
+
+    public static List<Tag> findByProjectId(Long projectId) {
+        return find.where().eq("project.id", projectId).findList();
+    }
+
+    public static Tag findById(Long id) {
+        return find.byId(id);
+    }
+
+    @Transient
+    public boolean exists() {
+        return find.where().eq("name", name).findRowCount() > 0;
+    }
+
+    @Override
+    public void delete() {
+        for(Project project: projects) {
+            project.tags.remove(this);
+            project.save();
+        }
+        super.delete();
+    }
+
+    public Resource asResource() {
+        return new Resource() {
+            @Override
+            public Long getId() {
+                return id;
+            }
+
+            @Override
+            public Project getProject() {
+                return null;
+            }
+
+            @Override
+            public ResourceType getType() {
+                return ResourceType.TAG;
+            }
+        };
+    }
+}

--- a/app/models/enumeration/ResourceType.java
+++ b/app/models/enumeration/ResourceType.java
@@ -21,7 +21,8 @@ public enum ResourceType {
     PROJECT("project"),
     ATTACHMENT("attachment"),
     ISSUE_COMMENT("issue_comment"),
-    NONISSUE_COMMENT("nonissue_comment");
+    NONISSUE_COMMENT("nonissue_comment"),
+    TAG("tag");
 
     private String resource;
 

--- a/app/views/project/projectHome.scala.html
+++ b/app/views/project/projectHome.scala.html
@@ -27,7 +27,10 @@
                     <strong>라이센스 :</strong> GPL v2
                 </li>
                 <li class="info">
-                    <strong>운영체제 :</strong> 리눅스
+                    <strong>@Messages("project.tags") :</strong>
+                    @for(tag <- project.tags) {
+                    <span class='label label-info'>@tag.name</span>
+                    }
                 </li>
                 <li class="info">
                     <strong>프로그래밍 언어 :</strong> PHP, Python, Java

--- a/app/views/project/projectList.scala.html
+++ b/app/views/project/projectList.scala.html
@@ -37,6 +37,9 @@
                   <div class="header">
                       <a href="@routes.UserApp.userInfo(project.owner)">@project.owner</a> / <a href="@routes.ProjectApp.project(project.owner, project.name)" class="project-name">@project.name</a>
             		  @if(!project.share_option){ <i class="ico ico-lock"></i> }
+                      @for(tag <- project.tags) {
+                      <span class='label label-info'>@tag.name</span>
+                      }
                   </div>
                   <div class="desc">
                       @project.overview

--- a/app/views/project/setting.scala.html
+++ b/app/views/project/setting.scala.html
@@ -54,6 +54,17 @@
                 </dl>
             </div>
             <div class="box-wrap middle">
+                <div class="cu-label">@Messages("project.tags")</div>
+                <div class="cu-desc">
+                    <div id="tags">
+                        <!-- tags will be added here by hive.project.Settings.js -->
+                    </div>
+                    <input name="newTag" type="text" class="text" style="margin-bottom: 0px"
+                        data-provider="typeahead" autocomplete="off"/>
+                    <a href="javascript:void(0)" class="n-btn small orange" id="addTag">@Messages("button.add")</a>
+                </div>
+            </div>
+            <div class="box-wrap middle">
                 <div class="cu-label">@Messages("project.shareOption")</div>
                 <div class="cu-desc">
                     <input name="share_option" type="radio" @if(project.share_option == true){checked="checked"} id="public" value="true" class="radio-btn"><label for="public" class="bg-radiobtn label-public">@Messages("project.public")</label>
@@ -103,8 +114,12 @@
 
 <script type="text/javascript">
 	$(document).ready(function(){
-		$hive.loadModule("project.Setting");
+        $hive.loadModule("project.Setting", {
+			"sURLProjectTags": "@routes.ProjectApp.tags(project.owner, project.name)",
+            "sURLTags"       : "@routes.TagApp.tags()"
+        });
 	});
+
 </script>
 
 }

--- a/app/views/user/info.scala.html
+++ b/app/views/user/info.scala.html
@@ -100,6 +100,11 @@
 						</h3>
 						<div class="stream-desc-wrap">
 							<div class="stream-desc">
+                                <p class="tags">
+                                @for(tag <- project.tags) {
+                                    <span class='label label-info'>@tag.name</span>
+                                }
+                                </p>
 								<p class="nm">@project.overview</p>
 								<p class="date">Last updated @agoString(project.ago)</p>
 							</div>

--- a/conf/evolutions/default/8.sql
+++ b/conf/evolutions/default/8.sql
@@ -1,0 +1,20 @@
+# --- !Ups
+
+CREATE TABLE project_tag (
+  project_id                     BIGINT NOT NULL,
+  tag_id                         BIGINT NOT NULL,
+  CONSTRAINT pk_project_tag PRIMARY KEY (project_id, tag_id));
+
+CREATE TABLE tag (
+  id                       BIGINT NOT NULL,
+  name                      VARCHAR(255),
+  CONSTRAINT uq_tag_name UNIQUE (NAME),
+  CONSTRAINT pk_tag PRIMARY KEY (ID));
+
+CREATE SEQUENCE tag_seq;
+
+# --- !Downs
+
+DROP SEQUENCE IF EXISTS tag_seq;
+DROP TABLE IF EXISTS project_tag;
+DROP TABLE IF EXISTS tag;

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -249,6 +249,7 @@ project.new.vcsType.subversion = Subversion
 project.readme = You can see README.md here if you add it into the code repository.
 project.searchPlaceholder = search at current project
 project.wrongName = Project name is wrong
+project.tags = Tags
 
 #Site
 site.sidebar = Site Management

--- a/conf/messages.ko
+++ b/conf/messages.ko
@@ -248,6 +248,7 @@ project.new.vcsType.subversion = Subversion
 project.readme = 프로젝트에 대한 설명을 README.md 파일로 작성해서 코드저장소에 추가하면 이 곳에 나타납니다.
 project.searchPlaceholder = 현재 프로젝트에서 검색
 project.wrongName = 프로젝트 이름이 올바르지 않습니다.
+project.tags = 태그
 
 #Site
 site.sidebar = 사이트 관리

--- a/conf/routes
+++ b/conf/routes
@@ -59,6 +59,12 @@ GET     /:user/:project/post/:id/editform               controllers.BoardApp.edi
 POST    /:user/:project/post/:id/edit                   controllers.BoardApp.editPost(user, project, id:Long)
 GET     /:user/:project/post/:id/comment/:commentId/delete     controllers.BoardApp.deleteComment(user, project, id:Long, commentId:Long)
 
+# Tags
+GET    /tags                                            controllers.TagApp.tags(query: String ?= "")
+GET    /:user/:project/tags                             controllers.ProjectApp.tags(user, project)
+POST   /:user/:project/tags                             controllers.ProjectApp.tag(user, project)
+POST   /:user/:project/tags/:id                         controllers.ProjectApp.untag(user, project, id: Long)
+
 # Projects
 GET     /projectform                                    controllers.ProjectApp.newProjectForm()
 POST    /projects                                       controllers.ProjectApp.newProject()

--- a/public/javascripts/common/hive.Common.js
+++ b/public/javascripts/common/hive.Common.js
@@ -239,6 +239,30 @@ $hive = hive.Common = (function(){
 	function getTrim(sValue){
 		return sValue.trim().replace(htVar.rxTrim, '');
 	}
+
+    /**
+    * Return whether the given content range is an entire range for items.
+    * e.g) "items 10/10"
+    *
+    * @param {String} contentRange the vaule of Content-Range header from response
+    * @return {Boolean}
+    */
+    function isEntireRange(contentRange) {
+        var result, items, total;
+
+        if (contentRange) {
+            result = /items\s+([0-9]+)\/([0-9]+)/.exec(contentRange);
+            if (result) {
+                items = parseInt(result[1]);
+                total = parseInt(result[2]);
+                if (items < total) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
 	
 	/* public Interface */
 	return {
@@ -249,7 +273,8 @@ $hive = hive.Common = (function(){
 		"stopEvent": stopEvent,
 		"getContrastColor": getContrastColor,
 		"sendForm" : sendForm,
-		"getTrim"  : getTrim 
+		"getTrim"  : getTrim,
+        "isEntireRange": isEntireRange
 	};
 })();
 

--- a/public/javascripts/service/hive.project.Member.js
+++ b/public/javascripts/service/hive.project.Member.js
@@ -111,6 +111,33 @@
 			});
 		}
 
+        /**
+        * Data source for loginId typeahead while adding new member.
+        *
+        * For more information, See "source" option at
+        * http://twitter.github.io/bootstrap/javascript.html#typeahead
+        *
+        * @param {String} query
+        * @param {Function} process
+        */
+        function _userTypeaheadSource(query, process) {
+            if (query.match(htVar.lastQuery) && htVar.isLastRangeEntire) {
+                process(htVar.cachedUsers);
+            } else {
+                $('<form action="/users" method="GET">')
+                    .append($('<input type="hidden" name="query">').val(query))
+                    .ajaxForm({
+                        "dataType": "json",
+                        "success": function(data, status, xhr) {
+                            htVar.isLastRangeEntire = $hive.isEntireRange(xhr.getResponseHeader('Content-Range'));
+                            htVar.lastQuery = query;
+                            htVar.cachedUsers = data;
+                            process(data);
+                        }
+                    }).submit();
+            }
+        }
+
 		_init(htOptions);
 	};
 	

--- a/test/controllers/ProjectAppTest.java
+++ b/test/controllers/ProjectAppTest.java
@@ -1,0 +1,131 @@
+package controllers;
+
+import models.Project;
+import models.Tag;
+import models.User;
+import org.codehaus.jackson.JsonNode;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import play.libs.Json;
+import play.mvc.Result;
+import play.test.Helpers;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static play.test.Helpers.*;
+
+public class ProjectAppTest {
+    @BeforeClass
+    public static void beforeClass() {
+        callAction(
+                routes.ref.Application.init()
+        );
+    }
+
+    @Test
+    public void tag() {
+        running(fakeApplication(Helpers.inMemoryDatabase()), new Runnable() {
+            public void run() {
+                //Given
+                Map<String,String> data = new HashMap<String,String>();
+                data.put("name", "foo");
+                User admin = User.findByLoginId("admin");
+
+                //When
+                Result result = callAction(
+                        controllers.routes.ref.ProjectApp.tag("hobi", "nForge4java"),
+                        fakeRequest()
+                                .withFormUrlEncodedBody(data)
+                                .withHeader("Accept", "application/json")
+                                .withSession(UserApp.SESSION_USERID, admin.id.toString())
+                );
+
+                //Then
+                assertThat(status(result)).isEqualTo(OK);
+                Iterator<Map.Entry<String, JsonNode>> fields = Json.parse(contentAsString(result)).getFields();
+                Map.Entry<String, JsonNode> field = fields.next();
+                Tag expected = new Tag();
+                expected.id = Long.valueOf(field.getKey());
+                expected.name = field.getValue().asText();
+                assertThat(expected.name).isEqualTo("foo");
+                assertThat(Project.findByNameAndOwner("hobi", "nForge4java").tags.contains(expected)).isTrue();
+            }
+        });
+    }
+
+    @Test
+    public void tags() {
+        running(fakeApplication(Helpers.inMemoryDatabase()), new Runnable() {
+            public void run() {
+                //Given
+                Project project = Project.findByNameAndOwner("hobi", "nForge4java");
+
+                Tag tag1 = new Tag();
+                tag1.name = "foo";
+                tag1.save();
+                project.tags.add(tag1);
+                project.update();
+
+                Tag tag2 = new Tag();
+                tag2.name = "bar";
+                tag2.save();
+                project.tags.add(tag2);
+                project.update();
+
+                //When
+
+                Result result = callAction(
+                        controllers.routes.ref.ProjectApp.tags("hobi", "nForge4java"),
+                        fakeRequest().withHeader("Accept", "application/json")
+                );
+
+                //Then
+                assertThat(status(result)).isEqualTo(OK);
+                JsonNode json = Json.parse(contentAsString(result));
+                assertThat(json.has(tag1.id.toString())).isTrue();
+                assertThat(json.has(tag2.id.toString())).isTrue();
+                assertThat(json.get(tag1.id.toString()).asText()).isEqualTo("foo");
+                assertThat(json.get(tag2.id.toString()).asText()).isEqualTo("bar");
+            }
+        });
+    }
+
+    @Test
+    public void untag() {
+        running(fakeApplication(Helpers.inMemoryDatabase()), new Runnable() {
+            public void run() {
+                //Given
+                Project project = Project.findByNameAndOwner("hobi", "nForge4java");
+
+                Tag tag1 = new Tag();
+                tag1.name = "foo";
+                tag1.save();
+                project.tags.add(tag1);
+                project.update();
+                Long tagId = tag1.id;
+
+                assertThat(project.tags.contains(tag1)).isTrue();
+
+                Map<String,String> data = new HashMap<String,String>();
+                data.put("_method", "DELETE");
+                User admin = User.findByLoginId("admin");
+
+                //When
+                Result result = callAction(
+                        controllers.routes.ref.ProjectApp.untag("hobi", "nForge4java", tagId),
+                        fakeRequest()
+                                .withFormUrlEncodedBody(data)
+                                .withHeader("Accept", "application/json")
+                                .withSession(UserApp.SESSION_USERID, admin.id.toString())
+                );
+
+                //Then
+                assertThat(status(result)).isEqualTo(204);
+                assertThat(Project.findByNameAndOwner("hobi", "nForge4java").tags.contains(tag1)).isFalse();
+            }
+        });
+    }
+}


### PR DESCRIPTION
1. 태그는 프로젝트 관리 메뉴에서 프로젝트에 붙일 수 있습니다.
2. 프로젝트에 붙은 태그는 프로젝트 목록 페이지, Overview 페이지, 유저 페이지의 프로젝트 목록에서 확인 가능합니다.
3. 태그 추가시, 입력창에서 자동완성(typeahead)이 지원됩니다. 동작방식은 멤버추가시의 자동완성(nforge/hive#6)과 거의 같으나, 다음 두 가지가 다릅니다.
   - 자동완성 후보 목록을 가져오는 url이 `/tags`
   - 자동완성 후보의 json 포맷이, 아이디를 키로 이름을 값으로 하는 맵
4. overview 페이지에서 태그를 보여줄 공간을 확보하기 위해, 프로젝트 정보 상자에서 "OS" 항목을 지웠습니다.
