### PR TITLE
이슈 등록/수정에서 신규 라벨 추가시 Active 상태로 설정

### DIFF
--- a/public/javascripts/common/hive.Label.js
+++ b/public/javascripts/common/hive.Label.js
@@ -106,6 +106,7 @@ hive.Label = (function(htOptions){
 	 */
 	function _onCreateNewLabel(oLabel){
 		_addLabelIntoCategory(oLabel);
+		_setActiveLabel(oLabel.id, oLabel.color);
 	}
 	
 	/**


### PR DESCRIPTION
이슈 등록/수정 화면에서 라벨 추가시 해당 이슈에 할당되도록 설정합니다.
