### PR TITLE
HIVE-180 이슈 고급검색에서 마일스톤으로 검색되지 않는 버그 수정

### DIFF
--- a/app/views/issue/issueList.scala.html
+++ b/app/views/issue/issueList.scala.html
@@ -89,7 +89,7 @@
 							<div class="control-group">
 								<label class="control-label">@Messages("milestone")</label>
 								<div class="controls">
-									<div class="btn-group" data-name="milestone">
+									<div class="btn-group" data-name="milestoneId">
 										<button data-toggle="dropdown" class="btn dropdown-toggle bgwhite d-label input-medium">@Messages("milestone.state.all")</button>
 										<button data-toggle="dropdown" class="btn dropdown-toggle bgwhite"><span class="caret"></span></button>
 										<ul class="dropdown-menu">


### PR DESCRIPTION
화면에서 넘기는 매개변수랑 서버에서 받는 매개변수가 달라서 검색 조건이 적용되지 않음.
