### PR TITLE
HIVE-159 게시글 파일업로드 후 수정화면에서 파일목록이 나오지 않음

### DIFF
--- a/app/views/board/editPost.scala.html
+++ b/app/views/board/editPost.scala.html
@@ -46,7 +46,7 @@
 			<div class="avatar-wrap">
 				<img src="@User.findByLoginId(session.get("loginId")).avatarUrl" class="img-rounded" width="32" height="32" alt="avatar">
 			</div>
-			<div id="upload" class="attach-info-wrap" resourceType="@ResourceType.BOARD_POST">
+			<div id="upload" class="attach-info-wrap" resourceType="@ResourceType.BOARD_POST" resourceId="@postId">
 				<div>
 					<span class="progress-num">0%</span> <span class="sp-line">&nbsp;</span>
 					<strong>total</strong> <span class="total-num">0MB</span>

--- a/public/javascripts/service/hive.board.Write.js
+++ b/public/javascripts/service/hive.board.Write.js
@@ -82,7 +82,8 @@
 			  	"elTarget"    : htElement.welTarget,
 			  	"elTextarea"  : htElement.welTextarea,
 			  	"sTplFileItem": htVar.sTplFileItem,
-			  	"sAction"     : htVar.sUploaderAction
+			  	"sAction"     : htVar.sUploaderAction,
+			  	"sMode"       : htVar.sMode
 			});
 		}
 		

--- a/public/javascripts/service/hive.issue.Write.js
+++ b/public/javascripts/service/hive.issue.Write.js
@@ -65,7 +65,8 @@
 			  	"elTarget"    : htElement.welTarget,
 			  	"elTextarea"  : htElement.welTextarea,
 			  	"sTplFileItem": htVar.sTplFileItem,
-			  	"sAction"     : htVar.sUploaderAction
+			  	"sAction"     : htVar.sUploaderAction,
+			  	"sMode"       : htVar.sMode
 			});
 		}
 		


### PR DESCRIPTION
게시글 보기 페이지와 동일한 방식으로 fileupload 컴포넌트에 첨부파일 목록 노출 로직을 추가했습니다.

이슈, 일반게시판에 적용되었으며 아래내용은 별도로 논의되어야 할듯 합니다.
- 파일업로드 진행바 동작 방식(파일 여러개 업로드후 삭제시)
- 게시글 수정에서 첨부파일 삭제시 바로 반영되는 문제
