### PR TITLE
issue: bugfix for downloading issues as excel.

### DIFF
--- a/app/controllers/IssueApp.java
+++ b/app/controllers/IssueApp.java
@@ -25,16 +25,13 @@ import org.apache.tika.Tika;
 import com.avaje.ebean.Page;
 import com.avaje.ebean.ExpressionList;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Map;
 
-import static com.avaje.ebean.Expr.contains;
 import static com.avaje.ebean.Expr.icontains;
 
 public class IssueApp extends AbstractPostingApp {
@@ -149,14 +146,14 @@ public class IssueApp extends AbstractPostingApp {
 
     public static Result issuesAsExcel(ExpressionList<Issue> el, Project project)
             throws WriteException, IOException, UnsupportedEncodingException {
-        File excelFile = Issue.excelSave(el.findList(), project.name + "_issues");
+        byte[] excelData = Issue.excelFrom(el.findList());
+        String filename = HttpUtil.encodeContentDisposition(
+                project.name + "_issues_" + JodaDateUtil.today().getTime() + ".xls");
 
-        String filename = HttpUtil.encodeContentDisposition(excelFile.getName());
-
-        response().setHeader("Content-Type", new Tika().detect(excelFile));
+        response().setHeader("Content-Type", new Tika().detect(filename));
         response().setHeader("Content-Disposition", "attachment; " + filename);
 
-        return ok(excelFile);
+        return ok(excelData);
     }
 
     public static Result issue(String userName, String projectName, Long issueId) {

--- a/app/models/Issue.java
+++ b/app/models/Issue.java
@@ -104,18 +104,16 @@ public class Issue extends AbstractPosting {
     }
 
     /**
-     * JXL 라이브러리를 이용하여 엑셀 파일로 저장하며, 해당 파일이 저장된 주소를 반환한다.
+     * Generate a Microsoft Excel file in byte array from the given issue list,
+     * using JXL.
      *
-     * @param resultList 엑셀로 저장하고자 하는 리스트
-     * @param pageName   엑셀로 저장하고자 하는 목록의 페이지(내용, ex 이슈, 게시물 등) 이름
+     * @param issueList 엑셀로 저장하고자 하는 리스트
      * @return
      * @throws WriteException
      * @throws IOException
      * @throws Exception
      */
-    public static File excelSave(List<Issue> resultList, String pageName) throws WriteException, IOException {
-        String excelFile = pageName + "_" + JodaDateUtil.today().getTime() + ".xls";
-        String fullPath = "public/uploadFiles/" + excelFile;
+    public static byte[] excelFrom(List<Issue> issueList) throws WriteException, IOException {
         WritableWorkbook workbook = null;
         WritableSheet sheet = null;
 
@@ -131,7 +129,8 @@ public class Issue extends AbstractPosting {
         cf2.setBorder(Border.ALL, BorderLineStyle.THIN);
         cf2.setAlignment(Alignment.CENTRE);
 
-        workbook = Workbook.createWorkbook(new File(fullPath));
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        workbook = Workbook.createWorkbook(bos);
         sheet = workbook.createSheet(String.valueOf(JodaDateUtil.today().getTime()), 0);
 
         String[] labalArr = {"ID", "STATE", "TITLE", "ASSIGNEE", "DATE"};
@@ -140,8 +139,8 @@ public class Issue extends AbstractPosting {
             sheet.addCell(new Label(i, 0, labalArr[i], cf1));
             sheet.setColumnView(i, 20);
         }
-        for (int i = 1; i < resultList.size() + 1; i++) {
-            Issue issue = resultList.get(i - 1);
+        for (int i = 1; i < issueList.size() + 1; i++) {
+            Issue issue = issueList.get(i - 1);
             int colcnt = 0;
             sheet.addCell(new Label(colcnt++, i, issue.id.toString(), cf2));
             sheet.addCell(new Label(colcnt++, i, issue.state.toString(), cf2));
@@ -159,7 +158,8 @@ public class Issue extends AbstractPosting {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        return new File(fullPath);
+
+        return bos.toByteArray();
     }
 
     /**


### PR DESCRIPTION
An internel server error has been occured while trying to download
issues as a excel file because of the file does not exist. The reason of
the error is lack of the directory in which the excel file is saved, so
the error may be fixed easily by just creating the directory.

But I have found that saving excel file in a directory is not safe at
all because the directory is public so cannot be access-controlled. To
solve this problem, I have changed the form of excel data generated by
Issue model, from a regular file to byte array, to make them be in the
memory, not a directory.
