### PR TITLE
HIVE-192 마일스톤 보기에서 '완료율 순'을 누르면 에러

### DIFF
--- a/app/models/Milestone.java
+++ b/app/models/Milestone.java
@@ -58,11 +58,11 @@ public class Milestone extends Model {
     }
 
     public int getNumClosedIssues() {
-        return Issue.finder.where().eq("milestone", this).eq("state", State.CLOSED).findRowCount();
+    	return Issue.finder.where().eq("milestone", this).eq("state", State.CLOSED).findRowCount();
     }
 
     public int getNumOpenIssues() {
-        return Issue.finder.where().eq("milestone", this).eq("state", State.OPEN).findRowCount();
+    	return Issue.finder.where().eq("milestone", this).eq("state", State.OPEN).findRowCount();
     }
 
     public int getNumTotalIssues() {
@@ -139,13 +139,38 @@ public class Milestone extends Model {
      * @return
      */
     public static List<Milestone> findMilestones(Long projectId,
-                                                 State state, String sort, Direction direction) {
-        OrderParams orderParams = new OrderParams().add(sort, direction);
+                                                 State state, String sort, final Direction direction) {
+    	
+    	OrderParams orderParams = new OrderParams();
+    	
+    	if(!"completionRate".equals(sort)) {
+    		orderParams.add(sort, direction);	
+    	}
+    	    	
         SearchParams searchParams = new SearchParams().add("project.id", projectId, Matching.EQUALS);
-        if (state != null && state != State.ALL) {
+        if(state != null && state != State.ALL) {
             searchParams.add("state", state, Matching.EQUALS);
         }
-        return FinderTemplate.findBy(orderParams, searchParams, find);
+        
+        List<Milestone> milestones = FinderTemplate.findBy(orderParams, searchParams, find);
+
+        if("completionRate".equals(sort)) {
+        	Collections.sort(milestones, new Comparator<Milestone>() {
+				@Override
+				public int compare(Milestone o1, Milestone o2) {
+					int o1CompletionRate = o1.getCompletionRate();
+					int o2CompletionRate = o2.getCompletionRate();
+					
+					if(direction == Direction.ASC) {
+				        return (o1CompletionRate < o2CompletionRate ? -1 : (o1CompletionRate == o2CompletionRate ? 0 : 1));
+					} else {
+						return (o1CompletionRate < o2CompletionRate ? 1 : (o1CompletionRate == o2CompletionRate ? 0 : -1));
+					}
+				}
+			});
+        }
+        
+        return milestones;
     }
 
     public void updateWith(Milestone newMilestone) {

--- a/app/views/milestone/manage.scala.html
+++ b/app/views/milestone/manage.scala.html
@@ -55,7 +55,7 @@
 				<td><a href="@makeSortLink("title")">@Messages("label.title") @sortMark("title")</a></td>
 				<td>@Messages("label.contents")</td>
 				<td><a href="@makeSortLink("dueDate")">@Messages("label.dueDate") @sortMark("dueDate")</a></td>
-				<td><a href="@makeSortLink("completionRate")">@Messages("label.state") @sortMark("completionRate")</a></td>
+				<td><a href="@makeSortLink("state")">@Messages("label.state") @sortMark("state")</a></td>
 				<td>&nbsp;</td>
 			</tr>
 		</thead>


### PR DESCRIPTION
1. 마일스톤 관리 페이지의 상태 정렬이 동작하도록 수정했습니다.
2. 마일스톤 목록 페이지의 완료율 정렬이 동작하도록 수정했습니다.
