### PR TITLE
attachment: Add notices to each temp attachments.

### DIFF
--- a/app/views/board/editPost.scala.html
+++ b/app/views/board/editPost.scala.html
@@ -60,7 +60,7 @@
 			</div>
 			<script type="text/template" id="tplAttachedFile"><!--
 				--><li class="attached-file" data-name="${fileName}" data-href="${fileHref}" data-mime="${mimeType}" data-size="${fileSize}">
-				<strong>${fileName}(${fileSizeReadable})</strong><!--
+                <strong>${fileName}(${fileSizeReadable})${notice}</strong><!--
 				--><a class="attached-delete"><i class="ico btn-delete"></i></a></li>
 			</script>
 			<div class="attached-files-wrap">

--- a/app/views/board/newPost.scala.html
+++ b/app/views/board/newPost.scala.html
@@ -58,7 +58,7 @@
 			</div>
 			<script type="text/template" id="tplAttachedFile"><!--
 				--><li class="attached-file" data-name="${fileName}" data-href="${fileHref}" data-mime="${mimeType}" data-size="${fileSize}">
-				<strong>${fileName}(${fileSizeReadable})</strong><!--
+                <strong>${fileName}(${fileSizeReadable})${notice}</strong><!--
 				--><a class="attached-delete"><i class="ico btn-delete"></i></a></li>
 			</script>
 

--- a/app/views/board/post.scala.html
+++ b/app/views/board/post.scala.html
@@ -138,7 +138,7 @@
 
 <script type="text/template" id="tplAttachedFile"><!--
 	--><li class="attached-file" data-name="${fileName}" data-href="${fileHref}" data-mime="${mimeType}" data-size="${fileSize}">
-	<strong>${fileName}(${fileSizeReadable})</strong><!--
+    <strong>${fileName}(${fileSizeReadable})${notice}</strong><!--
 	--><a class="attached-delete"><i class="ico btn-delete"></i></a></li>
 </script>
 

--- a/app/views/issue/editIssue.scala.html
+++ b/app/views/issue/editIssue.scala.html
@@ -57,7 +57,7 @@
 		</div>
 		<script type="text/template" id="tplAttachedFile"><!--
 				--><li class="attached-file" data-name="${fileName}" data-href="${fileHref}" data-mime="${mimeType}" data-size="${fileSize}">
-				<strong>${fileName}(${fileSizeReadable})</strong><!--
+                <strong>${fileName}(${fileSizeReadable})${notice}</strong><!--
 				--><a class="attached-delete"><i class="ico btn-delete"></i></a></li>
 			</script>
 

--- a/app/views/issue/issue.scala.html
+++ b/app/views/issue/issue.scala.html
@@ -180,7 +180,7 @@
 
 <script type="text/template" id="tplAttachedFile"><!--
 	--><li class="attached-file" data-name="${fileName}" data-href="${fileHref}" data-mime="${mimeType}" data-size="${fileSize}">
-	<strong>${fileName}(${fileSizeReadable})</strong><!--
+    <strong>${fileName}(${fileSizeReadable})${notice}</strong><!--
 	--><a class="attached-delete"><i class="ico btn-delete"></i></a></li>
 </script>
 

--- a/app/views/issue/newIssue.scala.html
+++ b/app/views/issue/newIssue.scala.html
@@ -55,7 +55,7 @@
 		</div>
 		<script type="text/template" id="tplAttachedFile"><!--
 				--><li class="attached-file" data-name="${fileName}" data-href="${fileHref}" data-mime="${mimeType}" data-size="${fileSize}">
-				<strong>${fileName}(${fileSizeReadable})</strong><!--
+                <strong>${fileName}(${fileSizeReadable})${notice}</strong><!--
 				--><a class="attached-delete"><i class="ico btn-delete"></i></a></li>
 			</script>
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -436,3 +436,6 @@ userinfo.starredProjects = Starred
 admin.resetPasswordEmail.title = [HIVE] Password reset mail request
 admin.resetPasswordEmail.mailcontents = copy the below url and paste it to browser url bar
 admin.resetPasswordEmail.invalidRequest = Invalid Password Reset Request
+
+#Attachment
+attach.attachIfYouSave = This will be attached if you save

--- a/conf/messages.ko
+++ b/conf/messages.ko
@@ -448,3 +448,6 @@ userinfo.starredProjects = 관심 프로젝트
 admin.resetPasswordEmail.title = [HIVE] 비밀번호 재 설정
 admin.resetPasswordEmail.mailcontents = 아래 URL을 브라우저 주소창에 붙여 넣으세요
 admin.resetPasswordEmail.invalidRequest = 잘못된 비밀번호 재 설정 요청입니다.
+
+#Attachment
+attach.attachIfYouSave = 저장하면 첨부됩니다

--- a/public/javascripts/common/hive.FileUploader.js
+++ b/public/javascripts/common/hive.FileUploader.js
@@ -26,9 +26,7 @@ hive.FileUploader = (function() {
 		_initVar(htOptions);
 		_attachEvent();
 		
-		if(htVar.sMode == "edit") {
-			_requestList();			
-		}
+        _requestList();
 	}
 	
 	/**
@@ -109,25 +107,32 @@ hive.FileUploader = (function() {
 	}
 	
 	function _onLoadRequest(oRes) {
+        var fAddFiles = function(aFiles, sNotice) {
+            var totalFileSize = 0;
 
-		var aItems = [];
-		var aFiles = oRes.attachments;
+            if (sNotice === undefined || sNotice === null) {
+                sNotice = "";
+            }
 
-		if(aFiles == null || aFiles.length === 0){
-			return;
-		}
-		
-		var totalFileSize = 0;
-		aFiles.forEach(function(oFile) {
-			var welItem = _createFileItem(oFile);
-			welItem.click(_onClickListItem);
-			htElements.welFileList.append(welItem);
-			totalFileSize = totalFileSize + parseInt(oFile.size);
-		});
+            if(aFiles != null && aFiles.length !== 0){
+                aFiles.forEach(function(oFile) {
+                    var welItem = _createFileItem(oFile, sNotice);
+                    welItem.click(_onClickListItem);
+                    htElements.welFileList.append(welItem);
+                    totalFileSize = totalFileSize + parseInt(oFile.size);
+                });
+            }
+
+            return totalFileSize;
+        }
+
+        var totalFileSize = 0;
+
+        totalFileSize += fAddFiles(oRes.attachments);
+        totalFileSize += fAddFiles(oRes.tempFiles, _attachIfYouSaveNotice());
 		
 		_setProgressBar(100);
 		_updateTotalFilesize(totalFileSize);
-		
 	}
 	
 	/**
@@ -176,6 +181,10 @@ hive.FileUploader = (function() {
 		
 		return !(sFileName == "");
 	}
+
+    function _attachIfYouSaveNotice() {
+        return " (" + Messages("attach.attachIfYouSave") + ")";
+    }
 	
 	/**
 	 * On success to submit temporary form created in onChangeFile()
@@ -193,7 +202,7 @@ hive.FileUploader = (function() {
 		}
 
 		// create list item
-		var welItem = _createFileItem(oRes);
+        var welItem = _createFileItem(oRes, _attachIfYouSaveNotice());
 		welItem.click(_onClickListItem);
 		htElements.welFileList.append(welItem);
 		
@@ -216,15 +225,16 @@ hive.FileUploader = (function() {
 	 * @param {Hash Table} htFile
 	 * @returns {HTMLElement} 
 	 */
-	function _createFileItem(htFile) {
+	function _createFileItem(htFile, sNotice) {
 		var oItem = $.tmpl(htVar.sTplFileItem, {
 			"mimeType": htFile.mimeType,
 			"fileName": htFile.name,
 			"fileHref": htFile.url,
 			"fileSize": htFile.size,
-			"fileSizeReadable": humanize.filesize(htFile.size)
+			"fileSizeReadable": humanize.filesize(htFile.size),
+            "notice": sNotice
 		});
-		
+
 		return oItem;
 	}
 	


### PR DESCRIPTION
파일을 업로드하면, 게시물에 실제로 첨부되기 전에는 파일을 업로드한 사용자에게 첨부되어있는 상태가 되며, 해당 게시물을 저장해야만 실제로 첨부가 됩니다.

이 사실을 명시적으로 알려줍니다. (좀 못생긴 방법)

![-](https://f.cloud.github.com/assets/1129852/493874/8975d806-bb73-11e2-8598-fde9838f1f56.png)
