### PR TITLE
label: Allow only members to edit labels.

### DIFF
--- a/app/controllers/IssueLabelApp.java
+++ b/app/controllers/IssueLabelApp.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import models.IssueLabel;
 import models.Project;
 import models.enumeration.Operation;
+import models.enumeration.ResourceType;
 import play.mvc.Controller;
 import play.mvc.Result;
 import utils.AccessControl;
@@ -40,8 +41,14 @@ public class IssueLabelApp extends Controller {
     public static Result newLabel(String userName, String projectName) {
         Form<IssueLabel> labelForm = new Form<IssueLabel>(IssueLabel.class).bindFromRequest();
 
+        Project project = ProjectApp.getProject(userName, projectName);
+
+        if (!AccessControl.isProjectResourceCreatable(UserApp.currentUser(), project, ResourceType.ISSUE_LABEL)) {
+            return forbidden();
+        }
+
         IssueLabel label = labelForm.get();
-        label.project = ProjectApp.getProject(userName, projectName);
+        label.project = project;
 
         if (label.exists()) {
             return ok();

--- a/app/views/issue/editIssue.scala.html
+++ b/app/views/issue/editIssue.scala.html
@@ -7,7 +7,6 @@
 @import utils.AccessControl._
 @import models.enumeration._
 
-
 @main(Messages(title), project, utils.MenuType.ISSUE) {
 
 <div class="page">
@@ -154,7 +153,8 @@
 			"sURLPost"     : "@routes.IssueLabelApp.newLabel(project.owner, project.name)",
 			"htActive"     : {@for(label <- issue.labels) { "@label.id":"@label.color", }"":""}
 		};
-		@if(ProjectUser.roleOf(session.get("loginId"), project).equals("manager")){
+
+        @if(isProjectResourceCreatable(UserApp.currentUser, project, ResourceType.ISSUE_LABEL)){
 			htOptLabel.bEditable = true;
 		}
 		

--- a/app/views/issue/issueList.scala.html
+++ b/app/views/issue/issueList.scala.html
@@ -5,6 +5,7 @@
 @import utils.TemplateHelper._
 @import scala.collection.immutable.Map
 @import models.enumeration._
+@import utils.AccessControl._
 
 @urlToList = {@routes.IssueApp.issues(project.owner, project.name, param.state, "html", currentPage.getPageIndex + 1)}
 
@@ -160,7 +161,8 @@
 			"sURLLabels"   : "@routes.IssueLabelApp.labels(project.owner, project.name)",
 			"sURLPost"     : "@routes.IssueLabelApp.newLabel(project.owner, project.name)"
 		};
-		@if(ProjectUser.roleOf(session.get("loginId"), project).equals("manager")){
+
+        @if(isProjectResourceCreatable(UserApp.currentUser, project, ResourceType.ISSUE_LABEL)){
 		htOptLabel.bEditable = true;
 		}
 

--- a/app/views/issue/newIssue.scala.html
+++ b/app/views/issue/newIssue.scala.html
@@ -131,7 +131,8 @@
 			"sURLLabels"   : "@routes.IssueLabelApp.labels(project.owner, project.name)", 
 			"sURLPost"     : "@routes.IssueLabelApp.newLabel(project.owner, project.name)"
 		};				
-		@if(ProjectUser.roleOf(session.get("loginId"), project).equals("manager")){
+
+        @if(isProjectResourceCreatable(UserApp.currentUser, project, ResourceType.ISSUE_LABEL)){
 			htOptLabel.bEditable = true;
 		}
 	


### PR DESCRIPTION
지금은 프로젝트 관리자만이 라벨을 추가하거나 기존 라벨을 고칠 수 있게 되어있는데,
멤버라면 누구나 할 수 있게 고칩니다.
(참고로 지금은 "프로젝트 관리자"만 할 수 있기 때문에 "사이트 관리자"조차 못함) 

그리고 빠져있던 권한검사도 추가합니다.
