### PR TITLE
bug fixed : if the loginId does not exists, UserApp#authenticateWithPlai...

### DIFF
--- a/app/controllers/UserApp.java
+++ b/app/controllers/UserApp.java
@@ -392,6 +392,9 @@ public class UserApp extends Controller {
      * @return hashed password
      */
     public static String hashedPassword(String plainTextPassword, String passwordSalt) {
+        if (plainTextPassword == null  || passwordSalt == null) {
+            return null;
+        }
         return new Sha256Hash(plainTextPassword, ByteSource.Util.bytes(passwordSalt), HASH_ITERATIONS).toBase64();
     }
     


### PR DESCRIPTION
bug fixed : if the loginId does not exists, UserApp#authenticateWithPlainPassword throws NullpointerException
