### PR TITLE
issue: Fix an error while posting an issue.

### DIFF
--- a/app/controllers/IssueApp.java
+++ b/app/controllers/IssueApp.java
@@ -3,6 +3,7 @@ package controllers;
 import models.*;
 import models.enumeration.*;
 
+import play.data.DynamicForm;
 import play.mvc.Http;
 import views.html.issue.edit;
 import views.html.issue.view;

--- a/app/models/IssueMassUpdate.java
+++ b/app/models/IssueMassUpdate.java
@@ -1,6 +1,7 @@
 package models;
 
 import models.enumeration.State;
+import play.data.validation.Constraints;
 
 import java.util.List;
 
@@ -8,5 +9,7 @@ public class IssueMassUpdate {
     public State state;
     public User assignee;
     public Milestone milestone;
+
+    @Constraints.Required
     public List<Issue> issues;
 }

--- a/conf/routes
+++ b/conf/routes
@@ -102,7 +102,7 @@ GET     /:user/:project/milestone/:id                   controllers.MilestoneApp
 GET     /:user/:project/issues                          controllers.IssueApp.issues(user, project, state:String ?= "", format:String ?= "html", pageNum: Int ?= 1)
 GET     /:user/:project/issueform                       controllers.IssueApp.newIssueForm(user, project)
 POST    /:user/:project/issues                          controllers.IssueApp.massUpdate(user, project)
-POST    /:user/:project/issues                          controllers.IssueApp.newIssue(user, project)
+POST    /:user/:project/issues/latest                   controllers.IssueApp.newIssue(user, project)
 GET     /:user/:project/issue/:number                       controllers.IssueApp.issue(user, project, number:Long)
 GET     /:user/:project/issue/:number/editform              controllers.IssueApp.editIssueForm(user, project, number:Long)
 POST    /:user/:project/issue/:number/edit                  controllers.IssueApp.editIssue(user, project, number:Long)


### PR DESCRIPTION
지금 대량갱신과 새 이슈 등록에 대한 요청이 POST /:owner/:project/issues로 똑같아서 새 이슈 등록시 라우팅 에러가 발생하게 되는데,

이 패치는  POST /:owner/:project/issues 요청을 updateIssues() 한 군데에서 받은 뒤, 요청의 내용을 보고 massUpdate()와 newIssue()를 적절하게 호출해줌으로써 해결합니다.

근데 서로 다른 기능...으로 볼 수도 있을 것 같은 "대량 갱신"과 "새 이슈 등록"을 한 곳에서 처리해도 괜찮을까 하는 걱정이 좀 있네요.
