### PR TITLE
NOHEAD 페이지 보강

### DIFF
--- a/app/views/code/nohead.scala.html
+++ b/app/views/code/nohead.scala.html
@@ -1,16 +1,32 @@
 @(project: Project)
 
+@getCodeURL(project: Project) = @{
+    if(session == null){
+        CodeApp.getURL(project.owner, project.name)
+    } else {
+        defining(ProjectUser.roleOf(session.get("loginId"), project)) { role =>
+            if(role == "manager" || role == "member"){
+                CodeApp.getURL(project.owner, project.name).replace("://", "://" + session.get("loginId") + "@")
+            } else {
+                CodeApp.getURL(project.owner, project.name)
+            }
+        }
+    }
+}
+
 @main(Messages("title.commitHistory"), project, utils.MenuType.CODE) {
 <div class="page">
 	@prjmenu(project, utils.MenuType.CODE, "main-menu-only")
 		
 	<div class="row-fluid">
-		<div class="well span12">
-			<p>HEAD커밋이 존재하지 않습니다. 다음과 같은 방법을 시도해 보세요</p>
-			<pre><code>git clone @CodeApp.getURL(project.owner, project.name)
+		<div class="span12">
+			<h5>@Html(Messages("code.nohead"))</h5>
+            
+			<pre><code>git clone @getCodeURL(project)
+cd @project.name/
 touch readme.md
 git add readme.md
-git commit -m "init"
+git commit -m "Hello @Messages("hive.name")"
 git push origin master</code></pre>
 		</div>
 	</div>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -399,6 +399,7 @@ code.commits = Commits
 code.newer = Newer
 code.older = Older
 code.repoUrl = URL
+code.nohead = Create a new repository on the command line
 
 #mail
 mail.password = Password

--- a/conf/messages.ko
+++ b/conf/messages.ko
@@ -399,6 +399,7 @@ code.commits = 커밋
 code.newer = 이전
 code.older = 다음
 code.repoUrl = 저장소 URL
+code.nohead = 아직 저장소가 비어있습니다.<br>아래의 명령어를 이용해 저장소에 파일을 커밋해보세요 
 
 #mail
 mail.password = 비밀번호


### PR DESCRIPTION
- 안내 문구 변경
- 프로젝트 멤버인 경우 git clone 구문에 사용자명@주소 형태로 표시
- 다국어 처리 추가 등
