### PR TITLE
#236 toast UI 스타일 수정

### DIFF
--- a/app/assets/stylesheets/less/_hiveUI.less
+++ b/app/assets/stylesheets/less/_hiveUI.less
@@ -320,37 +320,45 @@ button.nbtn {
     position: fixed; 
     overflow: hidden;
     right: 0 !important; 
-    bottom: 0 !important;
-    margin: 10px; width:240px;
+    top: 0 !important;
+    margin: 10px; width:340px;
 
     .toast {
+        position:relative;
         display:inline-block;
-        width: 200px; height: 50px; /*line-height: 50px;*/
+        width: 300px; height: 50px;
         margin: 10px; padding: 10px;
-        outline:none; text-align: center; font-weight: bold;
+        outline:none; text-align: center; 
+        font-weight: bold;
         
-        border: 2px solid #3998BD;
-        color: #222; background-color: #76E4FF;
+        border: 2px solid @primary;
+        color: #222; background-color: #fff;
         -webkit-transition-duration: 0.3s;
         
         .opacity(0);
-        .box-shadow(0px 0px 5px rgba(240, 160, 132, 0.6));         
         .border-radius(2px);
+        /*.box-shadow(0px 0px 5px rgba(240, 160, 132, 0.6));*/         
         
         .btn-dismiss {
-            float: right;
-            line-height: 10px;
+            position:absolute;
+            top:5px; right:10px;
+            button { 
+                color:@primary;
+                font-size:15px;
+                font-weight:bold;
+            }
         }
+        
         .v { 
             display:inline-block; 
             width:0px; height:50px; 
             vertical-align:middle;
         }
         .msg { 
+            width:280px; font-size:15px;
             display:inline-block;
             word-wrap: break-word;
             word-break:break-all;
-            /*line-height:16px;*/
             margin: 0;
             vertical-align:middle;
         }

--- a/app/views/scripts.scala.html
+++ b/app/views/scripts.scala.html
@@ -20,7 +20,7 @@
 	<div class="btn-dismiss"><button type="button" class="btn-transparent">&times;</button></div>
 	<div class="center-text">
         <span class="v"></span>
-        <span class="msg"></span>
+        <p class="msg"></p>
     </div>
 </div>
 </script>


### PR DESCRIPTION
- 우측 하단에서 우측 상단으로 위치를 변경했습니다
- 배경색, 테두리 색을 수정하고 box-shadow 를 제거했습니다
- 메시지 영역의 가로폭을 늘렸습니다 (200px → 300px)
- 메시지 닫기 버튼의 크기를 키우고 색을 테두리 색과 같도록 변경했습니다
- 메시지가 두 줄 이상으로 표시될 때 세로 중앙정렬이 되지 않던 문제를 수정했습니다
