### PR TITLE
issue: Improve confusing UI for issuelabel.

### DIFF
--- a/app/views/issue/create.scala.html
+++ b/app/views/issue/create.scala.html
@@ -84,7 +84,13 @@
 	</ul>
 
 	<!-- issue.label js module appends a label selector here. -->
-	<p class="option-label">@Messages("label.select")</p>
+    <p class="option-label">@Messages("label.select")
+        @if(isProjectResourceCreatable(UserApp.currentUser, project, ResourceType.ISSUE_LABEL)){
+        <a id="manage-label-link" href="javascript:void(0)">
+            <i class="icon-cog"></i>
+        </a>
+		}
+    </p>
 	<fieldset class="labels issue-form-labels form-horizontal bubble-wrap gray"></fieldset>
 
 	<div class="actions">
@@ -105,10 +111,6 @@
 			"sURLLabels"   : "@routes.IssueLabelApp.labels(project.owner, project.name)",
 			"sURLPost"     : "@routes.IssueLabelApp.newLabel(project.owner, project.name)"
 		};
-
-        @if(isProjectResourceCreatable(UserApp.currentUser, project, ResourceType.ISSUE_LABEL)){
-			htOptLabel.bEditable = true;
-		}
 
 		$hive.loadModule("issue.Write", {
 			"sMode"			 : "new",

--- a/app/views/issue/edit.scala.html
+++ b/app/views/issue/edit.scala.html
@@ -99,7 +99,14 @@
 	</ul>
 
 	<!-- issue.label js module appends a label selector here. -->
-	<p class="option-label">@Messages("label.select")</p>
+    <p class="option-label">@Messages("label.select")
+        @if(isProjectResourceCreatable(UserApp.currentUser, project, ResourceType.ISSUE_LABEL)){
+        <a id="manage-label-link" href="javascript:void(0)">
+            <i class="icon-cog"></i>
+        </a>
+		}
+    </p>
+
 	<fieldset class="labels issue-form-labels form-horizontal bubble-wrap gray"></fieldset>
 
 	<div class="actions">
@@ -123,14 +130,11 @@
 			"htActive"     : {@for(label <- issue.labels) { "@label.id":"@label.color", }"":""}
 		};
 
-        @if(isProjectResourceCreatable(UserApp.currentUser, project, ResourceType.ISSUE_LABEL)){
-			htOptLabel.bEditable = true;
-		}
-
 		// hive.issue.Write
 		$hive.loadModule("issue.Write", {
 			"sMode"			 : "edit",
 			"elTextarea"	 : $("#body"),
+            "welBtnManageLabel" : $("#manage-label-link"),
 			"sUploaderAction": "@routes.AttachmentApp.uploadFile",
 			"htOptLabel"     : htOptLabel
 		});

--- a/app/views/issue/list.scala.html
+++ b/app/views/issue/list.scala.html
@@ -272,10 +272,6 @@
 			"sURLPost"     : "@routes.IssueLabelApp.newLabel(project.owner, project.name)"
 		};
 
-        @if(isProjectResourceCreatable(UserApp.currentUser, project, ResourceType.ISSUE_LABEL)){
-        htOptLabel.bEditable = true;
-		}
-
 		$hive.loadModule("issue.List", {
 			"elPagination": $("#pagination"),
             "welMassUpdateForm": $('#mass-update-form'),

--- a/conf/routes
+++ b/conf/routes
@@ -106,14 +106,14 @@ GET     /:user/:project/issues                          controllers.IssueApp.iss
 GET     /:user/:project/issueform                       controllers.IssueApp.newIssueForm(user, project)
 POST    /:user/:project/issues                          controllers.IssueApp.massUpdate(user, project)
 POST    /:user/:project/issues/latest                   controllers.IssueApp.newIssue(user, project)
-GET     /:user/:project/issue/:number                       controllers.IssueApp.issue(user, project, number:Long)
-GET     /:user/:project/issue/:number/editform              controllers.IssueApp.editIssueForm(user, project, number:Long)
-POST    /:user/:project/issue/:number/edit                  controllers.IssueApp.editIssue(user, project, number:Long)
-GET     /:user/:project/issue/:number/delete                controllers.IssueApp.deleteIssue(user, project, number:Long)
-POST    /:user/:project/issue/:number/comments              controllers.IssueApp.newComment(user, project, number:Long)
-GET     /:user/:project/issue/:number/comment/:commentId/delete         controllers.IssueApp.deleteComment(user, project, number:Long, commentId:Long)
+GET     /:user/:project/issue/$number<[0-9]+>                       controllers.IssueApp.issue(user, project, number:Long)
+GET     /:user/:project/issue/$number<[0-9]+>/editform              controllers.IssueApp.editIssueForm(user, project, number:Long)
+POST    /:user/:project/issue/$number<[0-9]+>/edit                  controllers.IssueApp.editIssue(user, project, number:Long)
+GET     /:user/:project/issue/$number<[0-9]+>/delete                controllers.IssueApp.deleteIssue(user, project, number:Long)
+POST    /:user/:project/issue/$number<[0-9]+>/comments              controllers.IssueApp.newComment(user, project, number:Long)
+GET     /:user/:project/issue/$number<[0-9]+>/comment/:commentId/delete         controllers.IssueApp.deleteComment(user, project, number:Long, commentId:Long)
 
-# Label
+# Issue Labels
 GET     /:user/:project/issue/labels                        controllers.IssueLabelApp.labels(user, project)
 POST	/:user/:project/issue/labels					    controllers.IssueLabelApp.newLabel(user, project)
 POST	/:user/:project/issue/label/:id/delete 	            controllers.IssueLabelApp.delete(user, project, id:Long)

--- a/public/javascripts/common/hive.Label.js
+++ b/public/javascripts/common/hive.Label.js
@@ -69,7 +69,7 @@ hive.Label = (function(htOptions){
 	 * initialize element variable
 	 */
 	function _initElement(){
-		htElement.welContainer  = $("fieldset.labels");
+		htElement.welContainer  = $("fieldset.labels").empty();
 		htElement.welForm = $('form#issue-form,form.form-search,form#search');
 		
 		// add label
@@ -180,11 +180,13 @@ hive.Label = (function(htOptions){
 			"labelCSS" : 'active-' + $hive.getContrastColor(oLabel.color)
 		});
 		
-		// 편집모드: 삭제 링크 추가
+		// 편집모드: 라벨 버튼을 항상 active 상태로 유지하고, 삭제 링크를 추가
 		if(htVar.bEditable){ 
+            welBtnLabelId.addClass('active');
 			welBtnLabelId.append(_getDeleteLink(oLabel.id, oLabel.color));
-		}
-		welBtnLabelId.click(_onClickLabel);
+		} else {
+            welBtnLabelId.click(_onClickLabel);
+        }
 		
 		// 이미 같은 카테고리가 있으면 거기에 넣고
 		var welCategory = $('fieldset.labels div[data-category="' + oLabel.category + '"]');

--- a/public/javascripts/service/hive.issue.Write.js
+++ b/public/javascripts/service/hive.issue.Write.js
@@ -37,6 +37,7 @@
 			htVar.sMode = htOptions.sMode || "new";
 			htVar.sUploaderAction = htOptions.sUploaderAction;
 			htVar.sTplFileItem = htOptions.sTplFileItem || (htElement.welTplFileItem ? htElement.welTplFileItem.text() : "");
+            htVar.htOptLabel = htOptions.htOptLabel || {};
 		}
 		
 		/**
@@ -46,6 +47,7 @@
 			htElement.welUploader = $(htOptions.elUploader || "#upload");
 			htElement.welTextarea = $(htOptions.elTextarea || "#body");
 			htElement.welInputTitle = $(htOptions.elInputTitle || "#title");
+			htElement.welBtnManageLabel = $(htOptions.welBtnManageLabel || "#manage-label-link");
 
 			htElement.welTplFileItem = $('#tplAttachedFile');			
 		}
@@ -55,7 +57,13 @@
 		 */
 		function _attachEvent(){
 			$("form").submit(_onSubmitForm);
+            htElement.welBtnManageLabel.click(_clickBtnManageLabel);
 		}
+
+        function _clickBtnManageLabel() {
+            htVar.htOptLabel.bEditable = !htVar.htOptLabel.bEditable;
+            _initLabel(htVar.htOptLabel);
+        }
 		
 		/**
 		 * initialize fileUploader


### PR DESCRIPTION
- Add a button to toggle label editor in create/edit page.
- Disable label editing on Advanced search box.

이슈 검색/등록/편집시 모두 라벨 관리/등록 영역이 나타나서 혼란스러우므로, 검색에선 아예 라벨 관리가 안되도록 했고, 등록/편집시에는 기어 아이콘을 눌러야 관리 UI가 나타나게 했습니다.

![label-editor-toggle](https://f.cloud.github.com/assets/1129852/636300/75410cea-d27d-11e2-9737-ada1797c7f3d.png)
