### PR TITLE
회원가입폼에서 스크립트 validation이 동작하지 않음 - IE9

### DIFF
--- a/app/views/scripts.scala.html
+++ b/app/views/scripts.scala.html
@@ -55,7 +55,7 @@
 		$(".n-tooltip").tooltip();	
 		
     	// jquery.placeholder plugin initiator
-        $('input, textarea').placeholder();
+        $('input[type=text], textarea').placeholder();
 
     	// show setting menu tooltips 
     	// with bootstrap if it can (temporary before redesign)


### PR DESCRIPTION
- IE9 환경에서 input type이 password인 엘리먼트에 JQuery Placeholder 플러그인을 적용하면 오류가 발생합니다.
- input element의 placeholder 속성을 제거하려다.. password에 적용하는 케이스는 없을것 같아서 placeholder 초기화부분을 수정했습니다.
