### PR TITLE
inline reloadMilestone event fix and markup refactoring

### DIFF
--- a/app/views/issue/create.scala.html
+++ b/app/views/issue/create.scala.html
@@ -48,7 +48,7 @@
 					</button>
 					<ul class="dropdown-menu">
 						@ProjectUser.options(project.id).map{ v =>
-						<li data-value="@v._1"><a href="javascript:void(0)">@v._2</a></li>
+						<li data-value="@v._1"><a>@v._2</a></li>
 						}
 					</ul>
 				</div>
@@ -62,7 +62,7 @@
                 @defining(Milestone.options(project.id)) { milestones =>
                     @if(milestones.isEmpty()) {
                         <a href="@routes.MilestoneApp.newMilestoneForm(project.owner, project.name)" target="_blank" class="nbtn medium black">@Messages("milestone.menu.new")</a>
-                        <i class="icon-refresh" style="cursor: pointer" onclick="javascript:reloadMilestone();"></i>
+                        <i class="icon-refresh"></i>
                     } else {
                         <div class="option-desc">
                             <div id="milestoneId" class="btn-group" data-name="milestoneId">
@@ -72,7 +72,7 @@
                                 </button>
                                 <ul class="dropdown-menu">
                                     @milestones.map{ v =>
-                                    <li data-value="@v._1"><a href="javascript:void(0)">@v._2</a></li>
+                                    <li data-value="@v._1"><a>@v._2</a></li>
                                     }
                                 </ul>
                             </div>
@@ -86,7 +86,7 @@
 	<!-- issue.label js module appends a label selector here. -->
     <p class="option-label">@Messages("label.select")
         @if(isProjectResourceCreatable(UserApp.currentUser, project, ResourceType.ISSUE_LABEL)){
-        <a id="manage-label-link" href="javascript:void(0)">
+        <a id="manage-label-link">
             <i class="icon-cog"></i>
         </a>
 		}
@@ -115,6 +115,8 @@
 		$hive.loadModule("issue.Write", {
 			"sMode"			 : "new",
 			"elTextarea"	 : $("#body"),
+            "sMilestoneRefresh": $("#milestoneOption .icon-refresh"),
+            "sIssueFormURL"  : "@routes.IssueApp.newIssueForm(project.owner, project.name)",
 			"sUploaderAction": "@routes.AttachmentApp.uploadFile",
 			"htOptLabel"     : htOptLabel
 		});
@@ -122,13 +124,5 @@
 
 	});
 
-    function reloadMilestone() {
-        $.get("@routes.IssueApp.newIssueForm(project.owner, project.name)", function(data){
-            var context = data.replace("<!DOCTYPE html>", "").trim();
-            var milestoneOptionDiv = $("#milestoneOption", context);
-            $("#milestoneOption").html(milestoneOptionDiv.html());
-            new hive.ui.Dropdown({"elContainer":"#milestoneId"});
-        });
-    };
 </script>
 }

--- a/app/views/issue/edit.scala.html
+++ b/app/views/issue/edit.scala.html
@@ -49,8 +49,8 @@
 						<span class="d-caret"><span class="caret"></span></span>
 					</button>
 					<ul class="dropdown-menu">
-						<li data-value="@State.OPEN.name" @if(issue.state == State.OPEN){data-selected="true" class="active"}><a href="javascript:void(0)">@Messages("issue.state.open")</a></li>
-						<li data-value="@State.CLOSED.name" @if(issue.state == State.CLOSED){data-selected="true" class="active"}><a href="javascript:void(0)">@Messages("issue.state.closed")</a></li>
+						<li data-value="@State.OPEN.name" @if(issue.state == State.OPEN){data-selected="true" class="active"}><a>@Messages("issue.state.open")</a></li>
+						<li data-value="@State.CLOSED.name" @if(issue.state == State.CLOSED){data-selected="true" class="active"}><a>@Messages("issue.state.closed")</a></li>
 					</ul>
 				</div>
              </div>
@@ -67,9 +67,9 @@
 						<span class="d-caret"><span class="caret"></span></span>
 					</button>
 					<ul class="dropdown-menu">
-                        <li data-value="" @if(issue.assignee == null){data-selected="true" class="active"}><a href="javascript:void(0)">@Messages("issue.noAssignee")</a></li>
+                        <li data-value="" @if(issue.assignee == null){data-selected="true" class="active"}><a>@Messages("issue.noAssignee")</a></li>
 						@ProjectUser.options(project.id).map{ v =>
-						<li data-value="@v._1" @if(issue.assignee != null && issue.assignee.user.id.toString() == v._1){data-selected="true" class="active"}><a href="javascript:void(0)">@v._2</a></li>
+						<li data-value="@v._1" @if(issue.assignee != null && issue.assignee.user.id.toString() == v._1){data-selected="true" class="active"}><a>@v._2</a></li>
 						}
 					</ul>
 				</div>
@@ -83,7 +83,7 @@
             @defining(Milestone.options(project.id)) { milestones =>
                 @if(milestones.isEmpty()) {
                     <a href="@routes.MilestoneApp.newMilestoneForm(project.owner, project.name)" target="_blank" class="nbtn medium black">@Messages("milestone.menu.new")</a>
-                    <i class="icon-refresh" style="cursor: pointer" onclick="javascript:reloadMilestone();"></i>
+                    <i class="icon-refresh"></i>
                 } else {
                     <div class="option-desc">
                         <div id="milestoneId" class="btn-group" data-name="milestoneId">
@@ -92,9 +92,9 @@
                                 <span class="d-caret"><span class="caret"></span></span>
                             </button>
                             <ul class="dropdown-menu">
-                                <li data-value="" @if(issue.milestone == null){data-selected="true" class="active"}><a href="javascript:void(0)">@Messages("none")</a></li>
+                                <li data-value="" @if(issue.milestone == null){data-selected="true" class="active"}><a>@Messages("none")</a></li>
                                 @milestones.map{ v =>
-                                <li data-value="@v._1" @if(issue.milestone != null && issue.milestone.id.toString() == v._1){data-selected="true" class="active"}><a href="javascript:void(0)">@v._2</a></li>
+                                <li data-value="@v._1" @if(issue.milestone != null && issue.milestone.id.toString() == v._1){data-selected="true" class="active"}><a>@v._2</a></li>
                                 }
                             </ul>
                         </div>
@@ -108,7 +108,7 @@
 	<!-- issue.label js module appends a label selector here. -->
     <p class="option-label">@Messages("label.select")
         @if(isProjectResourceCreatable(UserApp.currentUser, project, ResourceType.ISSUE_LABEL)){
-        <a id="manage-label-link" href="javascript:void(0)">
+        <a id="manage-label-link">
             <i class="icon-cog"></i>
         </a>
 		}
@@ -142,19 +142,12 @@
 			"sMode"			 : "edit",
 			"elTextarea"	 : $("#body"),
             "welBtnManageLabel" : $("#manage-label-link"),
+            "sMilestoneRefresh": $("#milestoneOption .icon-refresh"),
+            "sIssueFormURL"  : "@routes.IssueApp.newIssueForm(project.owner, project.name)",
 			"sUploaderAction": "@routes.AttachmentApp.uploadFile",
 			"htOptLabel"     : htOptLabel
 		});
 	});
-
-    function reloadMilestone() {
-        $.get("@routes.IssueApp.editIssueForm(project.owner, project.name, issue.getNumber)", function(data){
-            var context = data.replace("<!DOCTYPE html>", "").trim();
-            var milestoneOptionDiv = $("#milestoneOption", context);
-            $("#milestoneOption").html(milestoneOptionDiv.html());
-            new hive.ui.Dropdown({"elContainer":"#milestoneId"});
-        });
-    };
 </script>
 
 }

--- a/app/views/issue/list.scala.html
+++ b/app/views/issue/list.scala.html
@@ -58,10 +58,10 @@
                                             <span class="d-caret"><span class="caret"></span></span>
                                         </button>
                                         <ul class="dropdown-menu">
-                                            <li data-value="" data-selected="true" class="active"><a href="javascript:void(0)">@Messages("order.all")</a></li>
-                                            <li data-value="@User.anonymous.id"><a href="javascript:void(0)">@Messages("noAssignee")</a></li>
+                                            <li data-value="" data-selected="true" class="active"><a>@Messages("order.all")</a></li>
+                                            <li data-value="@User.anonymous.id"><a>@Messages("noAssignee")</a></li>
                                             @for(assignee <- project.assignees) {
-                                            <li data-value="@assignee.user.id"><a href="javascript:void(0)">@assignee.user.name (@assignee.user.loginId)</a></li>
+                                            <li data-value="@assignee.user.id"><a>@assignee.user.name (@assignee.user.loginId)</a></li>
                                             }
                                         </ul>
                                     </div>
@@ -76,10 +76,10 @@
 											<span class="d-caret"><span class="caret"></span></span>
 										</button>
 										<ul class="dropdown-menu">
-											<li data-value="" data-selected="true" class="active"><a href="javascript:void(0)">@Messages("milestone.state.all")</a></li>
-											<li data-value="0"><a href="javascript:void(0)">@Messages("noMilestone")</a></li>
+											<li data-value="" data-selected="true" class="active"><a>@Messages("milestone.state.all")</a></li>
+											<li data-value="0"><a>@Messages("noMilestone")</a></li>
 											@for(milestone <- Milestone.findByProjectId(project.id)) {
-											<li data-value="@milestone.id"><a href="javascript:void(0)">@milestone.title</a></li>
+											<li data-value="@milestone.id"><a>@milestone.title</a></li>
 											}
 										</ul>
 									</div>

--- a/app/views/issue/partial_list.scala.html
+++ b/app/views/issue/partial_list.scala.html
@@ -21,14 +21,14 @@
         <div class="contents">
             <label for="issue-@issue.id">
                 <div class="title">
-                    <div style="display: inline">
+                    <span>
                         <a href="@routes.IssueApp.issue(project.owner, project.name, issue.getNumber)">@issue.title</a>
-                    </div>
-                    <div style="display: inline">
+                    </span>
+                    <span>
                     @for(label <- issue.labels.toList.sortBy(r => (r.category, r.name))) {
                         @makeLabelLink(project, searchCondition, label)
                     }
-                    </div>
+                    </span>
 
                 </div>
 

--- a/app/views/issue/partial_massupdate.scala.html
+++ b/app/views/issue/partial_massupdate.scala.html
@@ -7,8 +7,8 @@
             <span class="d-caret"><span class="caret"></span></span>
         </button>
         <ul class="dropdown-menu">
-            <li data-value="@State.OPEN.name"><a href="javascript:void(0)">@Messages("issue.state.open")</a></li>
-            <li data-value="@State.CLOSED.name"><a href="javascript:void(0)">@Messages("issue.state.closed")</a></li>
+            <li data-value="@State.OPEN.name"><a>@Messages("issue.state.open")</a></li>
+            <li data-value="@State.CLOSED.name"><a>@Messages("issue.state.closed")</a></li>
         </ul>
     </div>
 
@@ -18,9 +18,9 @@
             <span class="d-caret"><span class="caret"></span></span>
         </button>
         <ul class="dropdown-menu">
-            <li data-value="@User.anonymous.id"><a href="javascript:void(0)">@Messages("noAssignee")</a></li>
+            <li data-value="@User.anonymous.id"><a>@Messages("noAssignee")</a></li>
             @for(member <- project.members()) {
-                <li data-value="@member.user.id"><a href="javascript:void(0)">@member.user.name (@member.user.loginId)</a></li>
+                <li data-value="@member.user.id"><a>@member.user.name (@member.user.loginId)</a></li>
             }
         </ul>
     </div>
@@ -31,9 +31,9 @@
             <span class="d-caret"><span class="caret"></span></span>
         </button>
         <ul class="dropdown-menu">
-            <li data-value="-1"><a href="javascript:void(0)">@Messages("noMilestone")</a></li>
+            <li data-value="-1"><a>@Messages("noMilestone")</a></li>
             @for(milestone <- Milestone.findByProjectId(project.id)) {
-                <li data-value="@milestone.id"><a href="javascript:void(0)">@milestone.title</a></li>
+                <li data-value="@milestone.id"><a>@milestone.title</a></li>
             }
         </ul>
     </div>
@@ -45,7 +45,7 @@
         </button>
         <ul class="dropdown-menu">
         @for(label <- IssueLabel.findByProject(project)) {
-            <li data-value="@label.id"><a href="javascript:void(0)">@label</a></li>
+            <li data-value="@label.id"><a>@label</a></li>
         }
         </ul>
     </div>
@@ -57,12 +57,12 @@
         </button>
         <ul class="dropdown-menu">
         @for(label <- IssueLabel.findByProject(project)) {
-            <li data-value="@label.id"><a href="javascript:void(0)">@label</a></li>
+            <li data-value="@label.id"><a>@label</a></li>
         }
         </ul>
     </div>
 
-    <button href="#deleteConfirm" data-toggle="modal" class="nbtn medium black" disabled="true">@Messages("issue.delete")</button>
+    <button href="#deleteConfirm" data-toggle="modal" class="nbtn medium black" disabled>@Messages("issue.delete")</button>
 
     @** Confirm to delete post **@
     <div id="deleteConfirm" class="modal hide fade">
@@ -75,7 +75,7 @@
         </div>
         <div class="modal-footer">
             <a id="delete" class="btn btn-danger med">@Messages("button.yes")</a>
-            <a href="#" class="btn med" data-dismiss="modal">@Messages("button.no")</a>
+            <a class="btn med" data-dismiss="modal">@Messages("button.no")</a>
         </div>
     </div>
 

--- a/public/javascripts/service/hive.issue.Write.js
+++ b/public/javascripts/service/hive.issue.Write.js
@@ -35,6 +35,8 @@
 		 */
 		function _initVar(htOptions){
 			htVar.sMode = htOptions.sMode || "new";
+      htVar.sIssueFormURL = htOptions.sIssueFormURL;
+      htVar.sMilestoneRefresh = htOptions.sMilestoneRefresh;
 			htVar.sUploaderAction = htOptions.sUploaderAction;
 			htVar.sTplFileItem = htOptions.sTplFileItem || (htElement.welTplFileItem ? htElement.welTplFileItem.text() : "");
             htVar.htOptLabel = htOptions.htOptLabel || {};
@@ -58,11 +60,22 @@
 		function _attachEvent(){
 			$("form").submit(_onSubmitForm);
             htElement.welBtnManageLabel.click(_clickBtnManageLabel);
+      $("body").on("click", htVar.sMilestoneRefresh, _reloadMilestone);
+      $(htVar.sMilestoneRefresh).click(_reloadMilestone);
 		}
 
         function _clickBtnManageLabel() {
             htVar.htOptLabel.bEditable = !htVar.htOptLabel.bEditable;
             _initLabel(htVar.htOptLabel);
+        }
+
+        function _reloadMilestone() {
+          $.get(htVar.sIssueFormURL, function(data){
+            var context = data.replace("<!DOCTYPE html>", "").trim();
+            var milestoneOptionDiv = $("#milestoneOption", context);
+            $("#milestoneOption").html(milestoneOptionDiv.html());
+            new hive.ui.Dropdown({"elContainer":"#milestoneId"});
+          });
         }
 		
 		/**

--- a/public/stylesheets/issue.css
+++ b/public/stylesheets/issue.css
@@ -83,6 +83,8 @@ p.ordering a[selected] { color: #666666 }
 
 .labels input { margin-left: 7px; }
 
+.icon-refresh { cursor: pointer; }
+
 .labels a.del-link {
   border: none;
   margin: 0;


### PR DESCRIPTION
이슈 URL을 받게 하여 service/hive.issue.Write.js 모듈에서 핸들러를 일괄 처리하도록 수정했습니다.

javascript:void(0)
부트스트랩 때문에 ul의 이벤트 핸들링에 a를 사용하는 것 같은데, javascript:void(0) 은 사용하지 않는 편이 좋은것 같습니다.
IE6에서의 버그도 있기도 하고 사실 분리형 자바스크립트에 어울리지 않습니다. href 속성을 명시적으로 선언하든지, 혹은 제거하는게 좋을 것 같습니다.

<div style="display: inline">
div 태그에 스타일로 display를 inline 으로 지정하던 것을 span태그로 교체했습니다.

몇몇 인라인 스타일을 스타일시트로 수정
