### PR TITLE
코드브라우저의 파일목록테이블에서 author 정보가 넘어오지 않는 문제 수정

### DIFF
--- a/app/playRepository/GitRepository.java
+++ b/app/playRepository/GitRepository.java
@@ -314,6 +314,7 @@ public class GitRepository implements PlayRepository {
             data.put("msg", commit.getShortMessage());
             setAvatar(data, commit.getAuthorIdent().getEmailAddress());
             data.put("createdDate", commit.getCommitTime() * 1000l);
+            data.put("author", commit.getAuthorIdent().getName());
             listData.put(treeWalk.getNameString(), data);
         }
         result.put("data", listData);


### PR DESCRIPTION
UI 작업 수정중 발견한 문제 입니다.

코드 브라우져에서 파일목록 테이블 에서 개별 파일이 아닌 파일 리스트가 보이는 부분에서

author 정보가 넘어오지 않아 committer link 가 제대로 동작하지 않는 문제가 있어 수정 합니다.
