### PR TITLE
add milestone progress to home(#319), issue list

### DIFF
--- a/app/assets/stylesheets/less/_common.less
+++ b/app/assets/stylesheets/less/_common.less
@@ -145,6 +145,7 @@ a {
 
 .margin-top-20   { margin-top:20px;   }
 .margin-left-20  { margin-left: 20px; }
+.margin-left-5   { margin-left:5px; }
 .margin-right-5  { margin-right:5px;  }
 .margin-right-i2 { margin-right:-2px !important; }
 

--- a/app/assets/stylesheets/less/_page.less
+++ b/app/assets/stylesheets/less/_page.less
@@ -917,15 +917,9 @@
 
         &.advanced {
             .srch-advanced {
-                text-align:left;
-                margin-top:10px;
-                display:block;
+                display:block; text-align:left;
+                margin:10px 0 20px;
                 border-top: 1px solid #D6D6D6;
-
-               /*.custom-label-category:before {
-                    content:'|'; margin-right:15px;
-                    color:#c1c1c1;
-               }*/
             }
             .btn-advanced {
                 i { .ico-arrow-up-blue; }
@@ -933,7 +927,11 @@
         }
         
         .labels-wrap { border-top:1px solid #ddd; padding-top:10px; }
-        
+        .milestone-info {
+            padding-bottom:20px;
+            margin-bottom:20px;
+            border-bottom:1px solid #ddd;
+        }
         .preset-list {
             padding-bottom:20px;
             margin-bottom:20px;
@@ -1528,6 +1526,30 @@
     }
 }
 
+.milestone-info {
+    margin-bottom:20px;
+    
+    .meta-info {
+        margin:5px;
+        .title    { font-size:12px; font-weight:bold; }
+        .sp       { margin: 0 5px; color:#E4E4E4; }
+        .due-date { color: #666; /*999;*/ }
+    }
+    .progress-wrap {
+        overflow: hidden;
+        color: #999;
+        font-size: 11px;
+    }
+    .desc {
+        font-size: 11px;
+        margin-top: 15px;
+        padding: 15px;
+        background-color: #EBEBEB;
+        border-top:1px solid #D3D3D3;
+        .border-radius(2px);
+    }
+}
+
 .milestones {
     list-style: none;
     margin: 0;
@@ -1660,7 +1682,7 @@
 .project-home {
     width:260px;
     padding: 10px;
-    font-size: 0;
+    /*font-size: 0;*/
 
     .issue-wrap {
         margin-bottom:15px;
@@ -1890,6 +1912,7 @@
     }
     &.issue {
         .title { width:80%;/*650px;*/ }
+        /*
         .badge {
             font-size:11px;
             text-shadow:none;
@@ -1898,7 +1921,17 @@
         .badge-issue-open {
             background-color:@secondary;
         }
+        */
     }
+}
+
+.badge {
+    font-size:11px;
+    text-shadow:none;
+    .border-radius(2px);
+}
+.badge-issue-open {
+    background-color:@secondary;
 }
 
 .board-body {

--- a/app/models/Issue.java
+++ b/app/models/Issue.java
@@ -1,6 +1,8 @@
 package models;
 
 import com.avaje.ebean.Ebean;
+import com.avaje.ebean.ExpressionList;
+
 import jxl.*;
 import jxl.format.*;
 import jxl.format.Colour;
@@ -154,41 +156,35 @@ public class Issue extends AbstractPosting {
     }
 
     /**
-     * {@code projectId} 프로젝트에
-     * {@link State} 상태 이면서
-     * {@link Assignee}가 담당자인 이슈 개수를 반환한다.
+     * {@code projectId} 프로젝트에서 인자 조건에 따른 이슈 개수를 반환한다.
      *
      * @param projectId
      * @param state
      * @param assigneeId
-     * @return
-     */
-    public static int countIssuesByAssigneeId(Long projectId, State state, Long assigneeId) {
-        if (state == State.ALL){
-            return finder.where().eq("project.id", projectId).eq("assignee.user.id", assigneeId).findRowCount();
-        } else {
-            return finder.where().eq("project.id", projectId).eq("state", state).eq("assignee.user.id", assigneeId).findRowCount();
-        }
-    }
-
-    /**
-     * {@code projectId} 프로젝트에
-     * {@link State} 상태 이면서
-     * {@link authorId}가 작성자인 이슈 개수를 반환한다.
-     *
-     * @param projectId
-     * @param state
      * @param authorId
+     * @param milestoneId
      * @return
      */
-    public static int countIssuesByAuthorId(Long projectId, State state, Long authorId) {
-        if (state == state.ALL){
-            return finder.where().eq("project.id", projectId).eq("authorId", authorId).findRowCount();
-        } else {
-            return finder.where().eq("project.id", projectId).eq("state", state).eq("authorId", authorId).findRowCount();
+    public static int countIssuesBy(Long projectId, State state, Long assigneeId, Long authorId, Long milestoneId) {
+        ExpressionList<Issue> exl = finder.where();
+        exl = exl.eq("project.id", projectId);
+        
+        if (state != State.ALL){
+            exl = exl.eq("state", state);
         }
+        if (assigneeId != null && assigneeId >= 0){
+            exl = exl.eq("assignee.user.id", assigneeId);
+        }
+        if (authorId != null && authorId >= 0){
+            exl = exl.eq("authorId", authorId);
+        }
+        if (milestoneId != null && milestoneId >= 0){
+            exl = exl.eq("milestone.id", milestoneId);
+        }
+        
+        return exl.findRowCount();
     }
-
+    
     /**
      * Generate a Microsoft Excel file in byte array from the given issue list,
      * using JXL.

--- a/app/views/issue/list.scala.html
+++ b/app/views/issue/list.scala.html
@@ -9,9 +9,9 @@
 
 @urlToList = {@routes.IssueApp.issues(project.owner, project.name, param.state, "html", currentPage.getPageIndex + 1)}
 
-@urlAssignedToMe = {@urlToList&assigneeId=@User.findByLoginId(session.get("loginId")).id}
+@urlAssignedToMe = {@urlToList&assigneeId=@User.findByLoginId(session.get("loginId")).id&milestoneId=@param.milestoneId}
 
-@urlAuthoredByMe = {@urlToList&authorLoginId=@session.get("loginId")}
+@urlAuthoredByMe = {@urlToList&authorLoginId=@session.get("loginId")&milestoneId=@param.milestoneId}
 
 @getPageListUrl(pageIndex:Integer) = {@routes.IssueApp.issues(project.owner, project.name, param.state, "html", pageIndex + 1)}
 
@@ -23,22 +23,12 @@
 	}
 }
 
-@countIssuesByState(state:State) = @{
-    if(param.assigneeId != null){
-        Issue.countIssuesByAssigneeId(project.id, state, UserApp.currentUser().id)
-    } else if(param.authorLoginId != null){
-        Issue.countIssuesByAuthorId(project.id, state, UserApp.currentUser().id)
-    } else {
-        Issue.countIssues(project.id, state)
-    }
-}
-
-@getTabLinkByState(state:State) = {@routes.IssueApp.issues(project.owner, project.name, state.state)@if(param.assigneeId != null){&assigneeId=@param.assigneeId}@if(param.authorLoginId != null){&authorLoginId=@param.authorLoginId}}
+@getTabLinkByState(state:State) = {@routes.IssueApp.issues(project.owner, project.name, state.state)@if(param.assigneeId != null){&assigneeId=@param.assigneeId}@if(param.authorLoginId != null){&authorLoginId=@param.authorLoginId}@if(param.milestoneId != null){&milestoneId=@param.milestoneId}}
 
 @main(Messages(title), project, utils.MenuType.ISSUE){
 <div class="page">
 	@prjmenu(project, utils.MenuType.ISSUE, "main-menu-only")
-	
+
 	<div class="pull-right">
         <a href="@routes.IssueApp.newIssueForm(project.owner, project.name)" class="nbtn medium orange last">@Messages("issue.menu.new")</a>
     </div>
@@ -48,7 +38,7 @@
         <li @if(param.state == state.state) { class="active" }>
             <a href="@getTabLinkByState(state)">
                 @Messages("issue.state." + state.name.toLowerCase())
-                <span class="num-badge">@countIssuesByState(state)</span>
+                <span class="num-badge">@Issue.countIssuesBy(project.id, state, param.assigneeId, User.findByLoginId(param.authorLoginId).id, param.milestoneId)</span>
             </a>
         </li>
     }
@@ -83,14 +73,22 @@
         </div>
         
         <div class="span3 search-wrap">
-            <div class="inner bggray">
+            <div class="inner bggray @if(param.authorLoginId != null || param.assigneeId != null || param.milestoneId != null){ advanced }">
                 <ul class="unstyled preset-list">
-                    <li @if(param.assigneeId == null && param.authorLoginId == null){ class="active"}><a href="@urlToList">@Messages("issue.list.all") <strong class="num-badge pull-right">@Issue.countIssues(project.id, State.ALL)</strong></a></li>
+                    <li @if(param.assigneeId == null && param.authorLoginId == null){ class="active"}><a href="@urlToList&milestoneId=@param.milestoneId">@Messages("issue.list.all") <strong class="num-badge pull-right">@Issue.countIssuesBy(project.id, State.ALL, null, null, param.milestoneId)</strong></a></li>
                     @if(UserApp.currentUser().id != -1l){
-                    <li @if(param.assigneeId == UserApp.currentUser().id){ class="active"}><a href="@urlAssignedToMe">@Messages("issue.list.assignedToMe") <strong class="num-badge pull-right">@Issue.countIssuesByAssigneeId(project.id, State.ALL, User.findByLoginId(session.get("loginId")).id)</strong></a></li>
+                    <li @if(param.assigneeId == UserApp.currentUser().id){ class="active"}><a href="@urlAssignedToMe">@Messages("issue.list.assignedToMe") <strong class="num-badge pull-right">@Issue.countIssuesBy(project.id, State.ALL, UserApp.currentUser().id, null, param.milestoneId)</strong></a></li>
                     }
-                    <li @if(param.authorLoginId == UserApp.currentUser().loginId){ class="active"}><a href="@urlAuthoredByMe">@Messages("issue.list.authoredByMe") <strong class="num-badge pull-right">@Issue.countIssuesByAuthorId(project.id, State.ALL, User.findByLoginId(session.get("loginId")).id)</strong></a></li>
+                    <li @if(param.authorLoginId == UserApp.currentUser().loginId){ class="active"}><a href="@urlAuthoredByMe">@Messages("issue.list.authoredByMe") <strong class="num-badge pull-right">@Issue.countIssuesBy(project.id, State.ALL, null, UserApp.currentUser().id, param.milestoneId)</strong></a></li>
                 </ul>
+
+                @if(param.milestoneId != null){
+                    @defining(Milestone.findById(param.milestoneId)){ milestone =>
+                        @if(milestone != null){
+                            @views.html.milestone.partial_status(milestone, project)
+                        }
+                    }
+                }
 
                 <form id="search" action="@routes.IssueApp.issues(project.owner, project.name, param.state)" method="get">
                     <input type="hidden" name="orderBy" value="@param.orderBy" class="h-value order">
@@ -112,7 +110,7 @@
                     <div id="advanced-search-form" class="srch-advanced">
                         <dl class="issue-option">
                             <dt>@Messages("author")</dt>
-                            <dd><input type="text" name="authorLoginId" class="input-medium"></dd>
+                            <dd><input type="text" name="authorLoginId" class="input-medium" value="@param.authorLoginId"></dd>
                         </dl>
                         <dl class="issue-option">
                             <dt>@Messages("assignee")</dt>
@@ -123,10 +121,10 @@
                                         <span class="d-caret"><span class="caret"></span></span>
                                     </button>
                                     <ul class="dropdown-menu">
-                                        <li data-value="" data-selected="true" class="active"><a>@Messages("order.all")</a></li>
+                                        <li data-value=""><a>@Messages("order.all")</a></li>
                                         <li data-value="@User.anonymous.id"><a>@Messages("noAssignee")</a></li>
                                         @for(assignee <- project.assignees) {
-                                        <li data-value="@assignee.user.id"><a>@assignee.user.name (@assignee.user.loginId)</a></li>
+                                        <li data-value="@assignee.user.id" @if(param.assigneeId != null && param.assigneeId == assignee.user.id){data-selected="true" class="active"}><a>@assignee.user.name (@assignee.user.loginId)</a></li>
                                         }
                                     </ul>
                                 </div>                                
@@ -141,10 +139,10 @@
                                         <span class="d-caret"><span class="caret"></span></span>
                                     </button>
                                     <ul class="dropdown-menu">
-                                        <li data-value="" data-selected="true" class="active"><a>@Messages("milestone.state.all")</a></li>
+                                        <li data-value=""><a>@Messages("milestone.state.all")</a></li>
                                         <li data-value="0"><a>@Messages("noMilestone")</a></li>
                                         @for(milestone <- Milestone.findByProjectId(project.id)) {
-                                        <li data-value="@milestone.id"><a>@milestone.title</a></li>
+                                        <li data-value="@milestone.id" @if(param.milestoneId != null && param.milestoneId == milestone.id){data-selected="true" class="active"}><a>@milestone.title</a></li>
                                         }
                                     </ul>
                                 </div>                                

--- a/app/views/milestone/list.scala.html
+++ b/app/views/milestone/list.scala.html
@@ -95,11 +95,11 @@
                         <span class="due-date">@Messages("label.dueDate") <strong>@milestone.getDueDateString</strong></span>
                         <span class="date">(@milestone.until)</span>
                     }
-                    <div class="issue-wrap btn-group pull-right">
-                        <a href="@makeIssuesLink(milestone.id,"open")" class="btn">
+                    <div class="issue-wrap nbtn-group pull-right">
+                        <a href="@makeIssuesLink(milestone.id,"open")" class="nbtn medium">
                             @Messages("issue.state.open") <strong class="num-badge open">@milestone.getNumOpenIssues</strong>
                         </a>
-                        <a href="@makeIssuesLink(milestone.id,"closed")" class="btn">
+                        <a href="@makeIssuesLink(milestone.id,"closed")" class="nbtn medium">
                             @Messages("issue.state.closed") <strong class="num-badge closed">@milestone.getNumClosedIssues</strong>
                         </a>
                     </div>
@@ -117,7 +117,7 @@
 					<div class="progress-label">
 						@** 0% 일 수도 있어서 최소한의 텍스트 영역 확보 **@
 						<div class="pull-left" style="width: @milestone.getCompletionRate%; min-width:100px;">
-							<a href="@makeIssuesLink(milestone.id,"closed")">@Messages("milestone.state.closed") <strong>@milestone.getCompletionRate%</strong></a>
+							<a href="@makeIssuesLink(milestone.id,"closed")">@Messages("issue.state.closed") <strong>@milestone.getCompletionRate%</strong></a>
 						</div>
 						<div class="pull-right">
 							<a href="@makeIssuesLink(milestone.id,"open")">@Messages("issue.state.open") <strong>@{100 - milestone.getCompletionRate}%</strong></a>

--- a/app/views/milestone/partial_status.scala.html
+++ b/app/views/milestone/partial_status.scala.html
@@ -1,0 +1,38 @@
+@(milestone: models.Milestone, project: Project)
+@import scala.collection.immutable._
+@import utils.TemplateHelper._
+@import utils.AccessControl._
+
+@urlToList = {@routes.MilestoneApp.milestones(project.owner, project.name)}
+
+@makeIssuesLink(mId: Long, _state: String) = @{
+    buildQueryString(routes.IssueApp.issues(project.owner, project.name, _state),
+        Map("milestone"->mId.toString)
+    )
+}
+
+<div class="milestone-info">
+    <div class="meta-info">
+        <a href="@routes.MilestoneApp.milestone(project.owner, project.name, milestone.id)" class="title">@milestone.title</a>
+        @if(milestone.dueDate != null) {
+            <span class="sp">|</span>
+            <span class="due-date">@Messages("label.dueDate") <strong>@milestone.getDueDateString</strong></span>
+            <span class="date">(@milestone.until)</span>
+        }
+    </div>
+
+    <div class="progress-wrap">
+        <div class="progress">
+            <div class="bar orange" style="width: @milestone.getCompletionRate%;"></div>
+        </div>
+        <div class="progress-label">
+            @**<!-- 0% 일 수도 있어서 최소한의 텍스트 영역 확보 -->**@
+            <div class="pull-left" style="width: @milestone.getCompletionRate%; min-width:100px;">
+                <a href="@makeIssuesLink(milestone.id,"closed")">@Messages("issue.state.closed") <strong>@milestone.getCompletionRate%</strong></a>
+            </div>
+            <div class="pull-right">
+                <a href="@makeIssuesLink(milestone.id,"open")">@Messages("issue.state.open") <strong>@{100 - milestone.getCompletionRate}%</strong></a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/views/milestone/view.scala.html
+++ b/app/views/milestone/view.scala.html
@@ -21,16 +21,16 @@
             <span class="due-date">@Messages("label.dueDate") <strong>@milestone.getDueDateString</strong></span>
             <span class="date">(@milestone.until)</span>
             }
-            <span class="badge badge-issue-@milestone.state.state.toLowerCase">@Messages("milestone.state." + milestone.state.state)</span>
+            <span class="badge badge-issue-@milestone.state.state.toLowerCase margin-left-5">@Messages("milestone.state." + milestone.state.state)</span>
         </small>
     </h3>
 
     <div class="progress">
-        <div class="bar bar-success" style="width: @milestone.getCompletionRate%;"></div>
+        <div class="bar orange" style="width: @milestone.getCompletionRate%;"></div>
     </div>
     <div class="progress-label clearfix">
         <div class="pull-left">
-            <a href="@makeIssuesLink(milestone.id,"closed")">@Messages("milestone.state.closed") <strong>@milestone.getCompletionRate%</strong></a>
+            <a href="@makeIssuesLink(milestone.id,"closed")">@Messages("issue.state.closed") <strong>@milestone.getCompletionRate%</strong></a>
         </div>
         <div class="pull-right">
             <a href="@makeIssuesLink(milestone.id,"open")">@Messages("issue.state.open") <strong>@{100 - milestone.getCompletionRate}%</strong></a>
@@ -42,25 +42,25 @@
     </div>
 
     <div class="issues">
-        <h5>
-            @Messages("menu.issue") <strong class="num-badge">@milestone.issues.size</strong>
-        </h5>
+        <h5 class="margin-bottom-20">@Messages("menu.issue") <strong class="num-badge">@milestone.issues.size</strong></h5>
+        
         @issue.partial_massupdate(project, IssueApp.SearchCondition.emptySearchCondition)
         @issue.partial_list(project,milestone.sortedByStateOfIssue(),IssueApp.SearchCondition.emptySearchCondition,0,0)
     </div>
 
     <div class="actrow right-txt" style="padding: 15px 0;">
         @if(isAllowed(UserApp.currentUser(), milestone.asResource(), Operation.DELETE)){
-        <a href="@routes.MilestoneApp.deleteMilestone(project.owner, project.name, milestone.id)" class="nbtn medium black">@Messages("milestone.delete")</a>
+        <a href="@routes.MilestoneApp.deleteMilestone(project.owner, project.name, milestone.id)" class="nbtn medium red pull-left">@Messages("milestone.delete")</a>
         }
+        
         @if(isAllowed(UserApp.currentUser(), milestone.asResource(), Operation.UPDATE)){
-        <a href="@routes.MilestoneApp.editMilestoneForm(project.owner, project.name, milestone.id)" class="nbtn medium">@Messages("button.edit")</a>
             @if(milestone.state == State.OPEN) {
-                <a href="@routes.MilestoneApp.close(project.owner, project.name, milestone.id)" class="nbtn medium green">@Messages("milestone.close")</a>
+                <a href="@routes.MilestoneApp.close(project.owner, project.name, milestone.id)" class="nbtn medium blue">@Messages("milestone.close")</a>
             }
             @if(milestone.state == State.CLOSED) {
-                <a href="@routes.MilestoneApp.open(project.owner, project.name, milestone.id)" class="nbtn medium orange">@Messages("milestone.open")</a>
+                <a href="@routes.MilestoneApp.open(project.owner, project.name, milestone.id)" class="nbtn medium white">@Messages("milestone.open")</a>
             }
+            <a href="@routes.MilestoneApp.editMilestoneForm(project.owner, project.name, milestone.id)" class="nbtn medium">@Messages("button.edit")</a>
         }
         <a href="@routes.MilestoneApp.milestones(project.owner, project.name)" class="nbtn medium orange">@Messages("button.list")</a>
     </div>

--- a/app/views/project/overview.scala.html
+++ b/app/views/project/overview.scala.html
@@ -100,16 +100,7 @@
         </div>
 
         <div class="span3">
-		    <div class="bubble-wrap gray project-home" style="width:260px;">
-		        <div class="issue-wrap center-txt">
-		            <a href="@routes.IssueApp.issues(project.owner, project.name, State.OPEN.state)" class="nbtn medium white">
-		                @Messages("issue.state.open") @Messages("menu.issue") <strong class="num-badge">@Issue.countIssues(project.id, State.OPEN)</strong>
-		            </a>
-		            <a href="@routes.IssueApp.issues(project.owner, project.name, State.CLOSED.state)" class="nbtn medium white last">
-		                @Messages("issue.state.closed") @Messages("menu.issue") <strong class="num-badge">@Issue.countIssues(project.id, State.CLOSED)</strong>
-		            </a>
-		        </div>
-
+		    <div class="bubble-wrap gray project-home" style="width:260px;">		        
 		        <div class="inner logo" style="background-image:url('@projectLogoImage');">
 		            @if(isAllowed(UserApp.currentUser(), project.labelsAsResource(), Operation.UPDATE)){
 		            <div class="edit">
@@ -117,6 +108,13 @@
 		            </div>
 		            }
 		        </div>
+
+                @defining(Milestone.findOpenMilestones(project.id)){ milestones =>
+                    @if(milestones.length > 0){
+                        @views.html.milestone.partial_status(milestones(0), project)
+                    }
+                }
+
 		        <div class="inner project-info">
 		            <header>
 		                <h3>@Messages("project.info")</h3>


### PR DESCRIPTION
프로젝트 홈
- 완료일순으로 가장 최근의 마일스톤 진행 상황을 프로젝트 홈에 표시
- 미해결/해결 이슈 숫자를 표시하던 영역은 삭제

마일스톤 > 상세보기
- 삭제 버튼을 좌측 끝으로 이동. 버튼 색상 변경 (black -> red)
- 진행률 표시 스타일 목록과 맞추어 수정
- 기타 여백 수정

이슈 목록
- 상세 검색 조건이 있을 때에는 검색 영역 표시하도록 수정
- 목록 탭, 내 이슈 링크 영역의 숫자 표시 오류 수정
- 상세 검색 조건에서 마일스톤 선택시 해당 마일스톤 진행 상황 표시

예) 마일스톤 qwer 을 선택하고, 내가 작성한 이슈 조건을 선택한 경우: 
- 목록 탭에 표시되는 숫자는 현재 조건하에서 해결/미해결 구분에 의한 것입니다
- 우측 목록에서 표시되는 '전체 이슈' 숫자는 현재 선택한 마일스톤에서의 전체 갯수
  ![aaaa2](https://f.cloud.github.com/assets/3163211/780359/f3cbc398-ea01-11e2-8810-7ebc9afc301e.png)
