### PR TITLE
fix #333 - add indicator before markdown randering to html

### DIFF
--- a/app/assets/stylesheets/less/_page.less
+++ b/app/assets/stylesheets/less/_page.less
@@ -1850,6 +1850,8 @@
         .border-radius(10px);
         background-color: @white;
         overflow: hidden;
+        position:relative;
+        min-height:150px;
         header {
             padding: 10px 25px;
             background-color: #F8F8F8;

--- a/app/views/markdown.scala.html
+++ b/app/views/markdown.scala.html
@@ -9,6 +9,7 @@
 <script type="text/javascript" src="@getJSLink("Markdown.Converter")"></script>
 <script type="text/javascript" src="@getJSLink("Markdown.Sanitizer")"></script>
 <script type="text/javascript" src="@getJSLink("lib/marked")"></script>
+<script type="text/javascript" src="@getJSLink("lib/spin")"></script>
 <script type="text/javascript">
 $(document).ready(function(){
     var htOptions = {

--- a/app/views/project/overview.scala.html
+++ b/app/views/project/overview.scala.html
@@ -60,6 +60,7 @@
 	                } else {
 	                    <div class="readme-wrap">
 	                        <header><i class="ico ico-readme-book"></i><strong>@project.getReadmeFileName</strong></header>
+	                        <div id="spin" style="position: absolute; top:50%; left:50%"></div>
 	                        <div class="readme-body" markdown="true">@project.readme</div>
 	                    </div>
 	                }

--- a/public/javascripts/common/hive.Markdown.js
+++ b/public/javascripts/common/hive.Markdown.js
@@ -50,26 +50,27 @@ hive.Markdown = function(htOptions){
 		htVar.sTplSwitch = htOptions.sTplSwitch;
         htVar.sIssuesUrl = htOptions.sIssuesUrl;
         htVar.sProjectUrl = htOptions.sProjectUrl;
-	}
-	
-	/**
-	 * initialize element
-     * @param {Hash Table} htOptions
-	 */
-	function _initElement(htOptions){
-		htElement.waTarget = $(htOptions.aTarget) || $("[markdown]");
-	}
-	
-	/**
-	 * Render as Markdown document
-     * @require showdown.js
-     * @require hljs.js
-	 * @param {String} sText
-	 * @return {String}
-	 */
-	function _renderMarkdown(sText) {
-    		
-		var options = {
+
+    htVar.htOptSpinner = {
+	      lines: 10,    // The number of lines to draw
+	      length: 8,    // The length of each line
+	      width: 4,     // The line thickness
+	      radius: 8,    // The radius of the inner circle
+	      corners: 1,   // Corner roundness (0..1)
+	      rotate: 0,    // The rotation offset
+	      direction: 1, // 1: clockwise, -1: counterclockwise
+	      color: '#000',  // #rgb or #rrggbb
+	      speed: 1.5,     // Rounds per second
+	      trail: 60,      // Afterglow percentage
+	      shadow: false,  // Whether to render a shadow
+	      hwaccel: false, // Whether to use hardware acceleration
+	      className: 'spinner', // The CSS class to assign to the spinner
+	      zIndex: 2e9, // The z-index (defaults to 2000000000)
+	      top: 'auto', // Top position relative to parent in px
+	      left: 'auto' // Left position relative to parent in px
+	  };    
+
+	  htVar.htOptMarked = {
 		  gfm: true,
 		  tables: true,
 		  breaks: false,
@@ -84,10 +85,28 @@ hive.Markdown = function(htOptions){
 		    return code;
 		  }
 		};
-		
-		var lexer = new marked.Lexer(options);
-		var tokens = lexer.lex(sText);
-		var sHTML = marked.parser(tokens);
+	}
+	
+	/**
+	 * initialize element
+     * @param {Hash Table} htOptions
+	 */
+	function _initElement(htOptions){
+		htElement.waTarget = $(htOptions.aTarget) || $("[markdown]");
+		htElement.elSpinTarget = document.getElementById('spin');
+	}
+	
+	/**
+	 * Render as Markdown document
+     * @require showdown.js
+     * @require hljs.js
+	 * @param {String} sText
+	 * @return {String}
+	 */
+	function _renderMarkdown(sText) {
+    var htLexer = new marked.Lexer(htVar.htOptMarked);
+		var htTokens = htLexer.lex(sText);
+		var sHTML = marked.parser(htTokens);
 
 		return sHTML;
 	}
@@ -126,7 +145,10 @@ hive.Markdown = function(htOptions){
 	 * @param {Wrapped Element} welTarget is not <textarea> or <input>
 	 */
 	function _setViewer(welTarget) {
-		welTarget.html(_renderMarkdown(welTarget.text())).show();
+		welTarget.html(function() { 
+			_startSpinner();
+			return _renderMarkdown(welTarget.text());
+		}).show('show',_stopSpinner);
 	}
 	
 	/**
@@ -145,6 +167,24 @@ hive.Markdown = function(htOptions){
 				_setViewer($(elTarget));
 			}
 		});
+	}
+
+	/**
+	 * Spinner 시작
+	 */
+	function _startSpinner(){
+    htVar.oSpinner = new Spinner(htVar.htOptSpinner)
+    htVar.oSpinner.spin(htElement.elSpinTarget);
+	}
+	
+	/**
+	 * Spinner 종료
+	 */
+	function _stopSpinner(){
+    if(htVar.oSpinner){
+        htVar.oSpinner.stop();
+    }
+    htVar.oSpinner = null;
 	}
 
 	// initialize

--- a/public/javascripts/lib/marked.js
+++ b/public/javascripts/lib/marked.js
@@ -70,7 +70,7 @@ block.normal = merge({}, block);
  */
 
 block.gfm = merge({}, block.normal, {
-  fences: /^ *(`{3,}|~{3,}) *(\w+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
+  fences: /^ *(`{3,}|~{3,}) *(\S+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
   paragraph: /^/
 });
 
@@ -352,7 +352,7 @@ Lexer.prototype.token = function(src, top) {
         type: this.options.sanitize
           ? 'paragraph'
           : 'html',
-        pre: cap[1] === 'pre',
+        pre: cap[1] === 'pre' || cap[1] === 'script',
         text: cap[0]
       });
       continue;
@@ -676,7 +676,7 @@ InlineLexer.prototype.output = function(src) {
     // text
     if (cap = this.rules.text.exec(src)) {
       src = src.substring(cap[0].length);
-      out += escape(cap[0]);
+      out += escape(this.smartypants(cap[0]));
       continue;
     }
 
@@ -719,6 +719,19 @@ InlineLexer.prototype.outputLink = function(cap, link) {
       : '')
       + '>';
   }
+};
+
+/**
+ * Smartypants Transformations
+ */
+
+InlineLexer.prototype.smartypants = function(text) {
+  if (!this.options.smartypants) return text;
+  return text
+    .replace(/--/g, '\u2014')
+    .replace(/'([^']*)'/g, '\u2018$1\u2019')
+    .replace(/"([^"]*)"/g, '\u201C$1\u201D')
+    .replace(/\.{3}/g, '\u2026');
 };
 
 /**
@@ -1007,7 +1020,72 @@ function merge(obj) {
  * Marked
  */
 
-function marked(src, opt) {
+function marked(src, opt, callback) {
+  if (callback || typeof opt === 'function') {
+    if (!callback) {
+      callback = opt;
+      opt = null;
+    }
+
+    if (opt) opt = merge({}, marked.defaults, opt);
+
+    var highlight = opt.highlight
+      , tokens
+      , pending
+      , i = 0;
+
+    try {
+      tokens = Lexer.lex(src, opt)
+    } catch (e) {
+      return callback(e);
+    }
+
+    pending = tokens.length;
+
+    var done = function(hi) {
+      var out, err;
+
+      if (hi !== true) {
+        delete opt.highlight;
+      }
+
+      try {
+        out = Parser.parse(tokens, opt);
+      } catch (e) {
+        err = e;
+      }
+
+      opt.highlight = highlight;
+
+      return err
+        ? callback(err)
+        : callback(null, out);
+    };
+
+    if (!highlight || highlight.length < 3) {
+      return done(true);
+    }
+
+    if (!pending) return done();
+
+    for (; i < tokens.length; i++) {
+      (function(token) {
+        if (token.type !== 'code') {
+          return --pending || done();
+        }
+        return highlight(token.text, token.lang, function(err, code) {
+          if (code == null || code === token.text) {
+            return --pending || done();
+          }
+          token.text = code;
+          token.escaped = true;
+          --pending || done();
+        });
+      })(tokens[i]);
+    }
+
+    return;
+  }
   try {
     if (opt) opt = merge({}, marked.defaults, opt);
     return Parser.parse(Lexer.lex(src, opt), opt);
@@ -1041,7 +1119,8 @@ marked.defaults = {
   smartLists: false,
   silent: false,
   highlight: null,
-  langPrefix: 'lang-'
+  langPrefix: 'lang-',
+  smartypants: false
 };
 
 /**


### PR DESCRIPTION
# Issue 333 해결을 위한 indicator 적용

issue 333  에 등록된 마크다운 렌더링이 오래걸릴때의 문제를 보안하기 위하여 서비스내에서 사용중인 spin.js 를 사용한 indicator 를 적용 하였습니다.
## 적용방향
- markdown.scala.html 파일에 spin.js include  추가
- overview.scala.html 'readme-wrap` 영역에 spinner 추가
- hive.Markdown.js 내부 view rendering 에 대한 before/after interrupt 로 indicator 사용.
- indicator 포지션을 잡기위하여 _page.less  내 'readme-wrap` 관련 _position_ , _min-height_ 값 적용
## comment

근본적인 rendering 속도에 대한 수정이 일어난 것은 아니지만 현재 적용된 marked 의 랜더링 퍼포먼스는 3000 라인이 넘어가는
마크다운 문서도 큰 이슈없이 잘 소화하고 있는 관계로 혹시모를 cpu 점유 및 메모리 문제, 즉 클라이언트의 이슈에 따라 렌더링이 오래 걸리는 경우를 대비하기 위한 방편으로 추가되었다고 생각 하시면 될듯합니다. 
