### PR TITLE
issue: change issue state at issue view page

### DIFF
--- a/app/assets/stylesheets/less/_page.less
+++ b/app/assets/stylesheets/less/_page.less
@@ -3603,3 +3603,23 @@ code.milestone-title{
 .dimmedColor {
   color: #eee;
 }
+
+.no-gradient{
+  background-image: none;
+}
+
+.btn-flat{
+  .active{
+    background-color: #4AB9EE;
+    color: #FFF;
+    text-shadow: none;
+    box-shadow: none;
+  }
+  .dirty{
+    background-color: #979797;
+  }
+  .btn{
+    padding-top: 2px;
+    padding-bottom: 2px;
+  }
+}

--- a/app/models/enumeration/State.java
+++ b/app/models/enumeration/State.java
@@ -1,5 +1,8 @@
 package models.enumeration;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public enum State {
     ALL("all"), OPEN("open"), CLOSED("closed"), REJECTED("rejected");
     private String state;

--- a/app/views/issue/view.scala.html
+++ b/app/views/issue/view.scala.html
@@ -15,6 +15,7 @@
 	#@issue.getNumber @issue.title
 	@** Messages(title) **@
 }
+@isFirstState(state:State) = {@if(issue.state.state == Issue.availableStates.get(0).state()){dirty}}
 
 @main(getTitle(issue, project).toString(), project, utils.MenuType.ISSUE){
 <div class="page board-view">
@@ -25,8 +26,15 @@
 		<div class="board-id div"><strong class="secondary-txt">#@issue.getNumber</strong></div>
 		<h1 class="title div">@issue.title</h1>
 		<div class="date div">@agoString(issue.ago)</div>
-		<div class="div">
-			<span class="badge badge-issue-@issue.state.state.toLowerCase">@Messages("issue.state." + issue.state.state)</span>
+		<div class="div btn-group btn-flat">
+        @for(state <- Issue.availableStates){
+            @if( state.state == issue.state.state ){
+            <a href="@routes.IssueApp.nextState(UserApp.currentUser().loginId, project.name, issue.getNumber)" class="btn active @isFirstState(issue.state) no-gradient">@Messages("issue.state." + issue.state.state)</a>
+            } else {
+            <a href="@routes.IssueApp.nextState(UserApp.currentUser().loginId, project.name, issue.getNumber)" class="btn no-gradient">@Messages("issue.state." + state.state)</a>
+            }
+        }
+
 		</div>
 	</div>
 

--- a/conf/routes
+++ b/conf/routes
@@ -120,6 +120,7 @@ POST    /:user/:project/issues/latest                   controllers.IssueApp.new
 GET     /:user/:project/issue/$number<[0-9]+>                       controllers.IssueApp.issue(user, project, number:Long)
 GET     /:user/:project/issue/$number<[0-9]+>/editform              controllers.IssueApp.editIssueForm(user, project, number:Long)
 POST    /:user/:project/issue/$number<[0-9]+>/edit                  controllers.IssueApp.editIssue(user, project, number:Long)
+GET    /:user/:project/issue/$number<[0-9]+>/nextstate                  controllers.IssueApp.nextState(user, project, number:Long)
 GET     /:user/:project/issue/$number<[0-9]+>/delete                controllers.IssueApp.deleteIssue(user, project, number:Long)
 POST    /:user/:project/issue/$number<[0-9]+>/comments              controllers.IssueApp.newComment(user, project, number:Long)
 GET     /:user/:project/issue/$number<[0-9]+>/comment/:commentId/delete         controllers.IssueApp.deleteComment(user, project, number:Long, commentId:Long)

--- a/test/models/IssueTest.java
+++ b/test/models/IssueTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import models.enumeration.State;
 import org.junit.Test;
 import org.junit.Before;
 
@@ -40,6 +41,7 @@ public class IssueTest extends ModelTest<Issue> {
         issue.setTitle("hello");
         issue.setBody("world");
         issue.setAuthor(author);
+        issue.state = State.OPEN;
         issue.save();
     }
 
@@ -115,5 +117,35 @@ public class IssueTest extends ModelTest<Issue> {
         assertThat(matcher.group()).isEqualTo("@admin");
         matcher.find();
         assertThat(matcher.group()).isEqualTo("@keesun");
+    }
+
+    @Test
+    public void nextState(){
+        //Given
+        issue.state = State.OPEN;
+
+        //When //Then
+        assertThat(issue.nextState()).isEqualTo(State.CLOSED);
+    }
+
+    @Test
+    public void previousState(){
+        //Given
+        issue.state = State.CLOSED;
+
+        //When //Then
+        assertThat(issue.previousState()).isEqualTo(State.OPEN);
+    }
+
+    @Test
+    public void toNextState(){
+        //Given
+        State exptected = issue.nextState();
+
+        //When
+        issue.toNextState();
+
+        //Then
+        assertThat(issue.state).isEqualTo(exptected);
     }
 }


### PR DESCRIPTION
![issuestateupdate](https://f.cloud.github.com/assets/520523/866561/0861139a-f695-11e2-9a9c-bff0ac3f28f8.png)

이슈 상태를 이슈 뷰 화면에서 바로 변경할 수 있는 기능 추가
### 추가로

마일스톤이나 담당자 등도 마찬가지로 바로 변경이 되었으면 좋겠다는 생각이 들었는데
이것들에 대해서는 목록 페이지의 UI를 그대로 가져올지 아니면 기존에 논의 되었던
본문조차도 수정 메뉴를 명시적으로 누르지 않고 inline형태로 수정하게 하는 등의
UI 변경에 대한 논의가 따로 필요할 것으로 보임.
