### PR TITLE
email 노티시 sender 이름 추가

### DIFF
--- a/app/controllers/AbstractPostingApp.java
+++ b/app/controllers/AbstractPostingApp.java
@@ -72,9 +72,11 @@ public class AbstractPostingApp extends Controller {
         public String getTitle();
         public String getHtmlMessage();
         public String getPlainMessage();
+        public User getSender();
         public Set<User> getReceivers();
         public String getMessage();
         public String getUrlToView();
+        
     }
 
     protected static abstract class AbstractNotification implements Notification {
@@ -91,9 +93,13 @@ public class AbstractPostingApp extends Controller {
     }
 
     public static class NotificationFactory {
-        public static Notification create(final Set<User> receivers, final String title,
+        public static Notification create(final User sender, final Set<User> receivers, final String title,
                                           final String message, final String urlToView) {
             return new AbstractNotification() {
+                public User getSender() {
+                    return sender;
+                }
+                
                 public String getTitle() {
                     return title;
                 }
@@ -184,11 +190,13 @@ public class AbstractPostingApp extends Controller {
 
         try {
             play.Configuration config = play.Configuration.root();
-            email.setFrom(Config.getEmailFromSmtp());
-            email.addTo(config.getString("smtp.user") + "@" + config.getString("smtp.domain"));
+            email.setFrom(noti.getSender().email, noti.getSender().name);
+            email.addTo(config.getString("smtp.user") + "@" + config.getString("smtp.domain"), "Yobi");
+            
             for (User receiver : receivers) {
                 email.addBcc(receiver.email, receiver.name);
             }
+            
             email.setSubject(noti.getTitle());
             email.setHtmlMsg(noti.getHtmlMessage());
             email.setTextMsg(noti.getPlainMessage());

--- a/app/models/NotificationEvent.java
+++ b/app/models/NotificationEvent.java
@@ -99,6 +99,10 @@ public class NotificationEvent extends Model {
         }
     }
 
+    public User getSender() {
+        return User.find.byId(this.senderId);
+    }
+    
     public Resource getResource() {
         Resource resource = null;
 

--- a/app/models/NotificationMail.java
+++ b/app/models/NotificationMail.java
@@ -81,6 +81,7 @@ public class NotificationMail extends Model {
                         if (mail.notificationEvent.resourceExists()) {
                             AbstractPostingApp.sendNotification(
                                     AbstractPostingApp.NotificationFactory.create(
+                                            mail.notificationEvent.getSender(),
                                             mail.notificationEvent.receivers,
                                             mail.notificationEvent.title,
                                             mail.notificationEvent.getMessage(),


### PR DESCRIPTION
아직 명세를 확인하진 못했지만 가장 빠르게 처리할 수 있는 방법으로 수정해 봤습니다.
- Before
  ![noti-before](https://f.cloud.github.com/assets/4167821/870758/307d8708-f836-11e2-858d-d7b51c654c29.PNG)
- After
  ![noti-after](https://f.cloud.github.com/assets/4167821/870756/2ec47480-f836-11e2-86e4-c94d3e47837e.PNG)
