### PR TITLE
modify userinfo/issue list style, make .nbtn flat

### DIFF
--- a/app/assets/stylesheets/less/_page.less
+++ b/app/assets/stylesheets/less/_page.less
@@ -934,6 +934,10 @@
             .btn-advanced {
                 i { .ico-arrow-up-blue; }
             }
+            .caret-wrap .caret { 
+                border-top:0; 
+                border-bottom:4px solid @blue;
+            }
         }
 
         .labels-wrap { padding-top:10px; }
@@ -1012,7 +1016,7 @@
     // -- project list -- //
     .project {
         margin: 5px 0px; /*5px 20px;*/
-        padding: 10px 20px;
+        padding: 10px 0px;
         overflow: hidden;
         border-bottom: 1px solid #DCDCDC;
         .info-wrap {
@@ -1097,7 +1101,7 @@
                 strong { color:@secondary; }
            }
 
-           .leaveProject { margin-top:2px; }
+           /*.leaveProject { margin-top:2px; }*/
         }
     }
 
@@ -1323,8 +1327,8 @@
       margin:0 !important;
     }
     .menu-list {
-      border: 2px solid #DADADA;
-      border-radius: 5px;
+      /*border: 2px solid #DADADA;
+      border-radius: 5px;*/
       width: auto;
       float: left;
     }

--- a/app/assets/stylesheets/less/_temporary.less
+++ b/app/assets/stylesheets/less/_temporary.less
@@ -29,3 +29,41 @@
         }
     }
 }
+
+.lst-stacked {
+    li {
+        font-size:13px;
+        padding:8px;
+        a { display: block}
+        .num-badge { padding:0 2px; }
+        
+        &.active {
+            color: #fff;
+            background: @secondary;
+            font-weight:bold;
+            .border-radius(2px);
+            .box-shadow(inset 1px 1px 1px rgba(0,0,0,0.2));
+            
+            .num-badge { color:#fff; }
+        }
+    }
+}
+
+.caret-wrap {
+    padding:5px;
+    
+    .caret {
+        display: inline-block;
+        width: 0;
+        height: 0;
+        vertical-align: top;
+        border-top: 4px solid @blue;
+        border-right: 4px solid transparent;
+        border-left: 4px solid transparent;
+        content: "";        
+        margin-top:9px;
+        
+        &.up { border-top:0; border-bottom-width:4px solid @blue; }
+        &.down { border-top:4px solid @blue; border-bottom:0; }
+    }
+}

--- a/app/assets/stylesheets/less/_yobiUI.less
+++ b/app/assets/stylesheets/less/_yobiUI.less
@@ -125,7 +125,7 @@ input[type="search"], input[type="tel"], input[type="color"], .uneditable-input 
     white-space:nowrap;
 
     .border-radius(2px);
-    .box-shadow(0 1px 2px rgba(0, 0, 0, .25));
+    /*.box-shadow(0 1px 2px rgba(0, 0, 0, .25));*/
     .inline-block;
     > i.ico { margin-right: 5px; }
 
@@ -141,6 +141,10 @@ input[type="search"], input[type="tel"], input[type="color"], .uneditable-input 
     &.blue {
         background-color: @blue2; /*#56B5D9*/
         &:hover { background-color: darken(@blue2, 10%); color: #00ddff; }
+        .num-badge { 
+            background-color:#fff;
+            color:@blue2;
+        }
     }
 
     &.orange {

--- a/app/views/board/view.scala.html
+++ b/app/views/board/view.scala.html
@@ -42,6 +42,12 @@
 		</div>
 	</div>
 	<div class="board-footer board-actrow">
+        <button id="watch-button" type="button" class="nbtn medium blue
+            @if(post.getWatchers.contains(UserApp.currentUser())) { active } else { inactive }"
+            data-toggle="button">
+            @Messages("notification.watch")
+        </button>
+	    
 		@if(isAllowed(UserApp.currentUser(), post.asResource(), Operation.DELETE)){
 		<a href="#deleteConfirm" class="nbtn medium red" data-toggle="modal">@Messages("button.delete")</a>
 		}
@@ -85,12 +91,6 @@
 	</div>
 	
 	@help.keymap("boardDetail", project)
-
-    <button type="button" class="btn small white
-        @if(post.getWatchers.contains(UserApp.currentUser())) { active } else { inactive }"
-        data-toggle="button" id="watch-button">
-        @Messages("notification.watch")
-    </button>
 </div>
 
 <script type="text/x-jquery-tmpl" id="tplAttachedFile"><!--

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -46,6 +46,7 @@
                 <ul class="activity-streams unstyled">
                     @for(noti <- UserApp.currentUser.notificationEvents){
                     <li class="activity-stream">
+                        @**<!--
                         @if(noti.getProject != null){
                         <a class="user-thumb-wrap" href="@routes.ProjectApp.project(noti.getProject.owner, noti.getProject.name)">
                         @defining(Attachment.findByContainer(ResourceType.PROJECT, noti.getProject.id)) { attachments =>
@@ -59,15 +60,16 @@
                         } else {
                         <a class="user-thumb-wrap"><img src="@routes.Assets.at("images/default-avatar-64.png")" width="62" height="62" alt="avatar"></a>
                         }
+                        -->**@
                         <div class="activity-desc">
                             <h5 class="header-text">
                                 <a href="@noti.urlToView">@noti.title</a>
                                 @defining(User.find.byId(noti.senderId)) { user =>
                                 @if(user != null) {
-                                by <a href="@routes.UserApp.userInfo(user.loginId)"><span class="date">@user.loginId</span></a>
+                                <a href="@routes.UserApp.userInfo(user.loginId)"><span class="date">@user.loginId</span></a>
                                 }
                                 }
-                                at <span class="date">@agoString(JodaDateUtil.ago(noti.created))</span>
+                                <span class="date">@agoString(JodaDateUtil.ago(noti.created))</span>
                             </h5>
                             <div class="desc">@noti.getMessage</div>
                         </div>

--- a/app/views/issue/list.scala.html
+++ b/app/views/issue/list.scala.html
@@ -32,18 +32,13 @@
 
 	<div class="pull-right">
         <div class="btn-group" style="margin-right: 20px;">
-            <a href="@urlToList&milestoneId=@param.milestoneId" @if(param.assigneeId == null && param.authorLoginId == null){class="btn active"} else {class="btn"}>@Messages("issue.list.all") <span class="num-badge">@Issue.countIssuesBy(project.id, State.ALL, null, null, param.milestoneId)</span></a>
-            @if(UserApp.currentUser().id != -1l){
-                <a href="@urlAssignedToMe" @if(param.assigneeId == UserApp.currentUser().id){ class="btn active"} else {class="btn"}>@Messages("issue.list.assignedToMe") <span class="num-badge">@Issue.countIssuesBy(project.id, State.ALL, UserApp.currentUser().id, null, param.milestoneId)</span></a>
-            }
-            <a href="@urlAuthoredByMe" @if(param.authorLoginId == UserApp.currentUser().loginId){ class="btn active"} else { class="btn"}>@Messages("issue.list.authoredByMe") <span class="num-badge">@Issue.countIssuesBy(project.id, State.ALL, null, UserApp.currentUser().id, param.milestoneId)</span></a>
             </div>
 
         <a href="@routes.IssueApp.newIssueForm(project.owner, project.name)" class="nbtn medium orange last">@Messages("issue.menu.new")</a>
     </div>
 
 	<ul class="nav nav-tabs nm">
-    @for(state <- Array(State.ALL, State.OPEN, State.CLOSED)) {
+    @for(state <- Array(State.OPEN, State.CLOSED)) {
         <li @if(param.state == state.state) { class="active" }>
             <a href="@getTabLinkByState(state)">
                 @Messages("issue.state." + state.name.toLowerCase())
@@ -86,6 +81,14 @@
         
         <div class="span3 search-wrap">
             <div class="inner bggray @if(param.authorLoginId != null || param.assigneeId != null || param.milestoneId != null){ advanced }">
+                <ul class="lst-stacked unstyled">
+                    <li @if(param.assigneeId == null && param.authorLoginId == null){class="active"}><a href="@urlToList&milestoneId=@param.milestoneId">@Messages("issue.list.all") <span class="num-badge pull-right">@Issue.countIssuesBy(project.id, State.ALL, null, null, param.milestoneId)</span></a></li>
+                    @if(UserApp.currentUser().id != -1l){
+                    <li @if(param.assigneeId == UserApp.currentUser().id){ class="active"}><a href="@urlAssignedToMe">@Messages("issue.list.assignedToMe") <span class="num-badge pull-right">@Issue.countIssuesBy(project.id, State.ALL, UserApp.currentUser().id, null, param.milestoneId)</span></a></li>
+                    }
+                    <li @if(param.authorLoginId == UserApp.currentUser().loginId){ class="active"}><a href="@urlAuthoredByMe">@Messages("issue.list.authoredByMe") <span class="num-badge pull-right">@Issue.countIssuesBy(project.id, State.ALL, null, UserApp.currentUser().id, param.milestoneId)</span></a></li>
+                </ul>
+
                 @if(param.milestoneId != null){
                     @defining(Milestone.findById(param.milestoneId)){ milestone =>
                         @if(milestone != null){
@@ -108,7 +111,10 @@
                     </div>
 
                     <div class="row-fluid right-txt">
-                        <button type="button" class="btn-advanced btn-transparent"><i class="icon-plus"></i>@Messages("issue.advancedSearch")</button>
+                        <button type="button" class="btn-advanced btn-transparent">
+                            <span class="caret-wrap"><span class="caret down blue"></span></span> 
+                            @Messages("issue.advancedSearch")
+                        </button>
                     </div>
 
                     <div id="advanced-search-form" class="srch-advanced">

--- a/app/views/issue/view.scala.html
+++ b/app/views/issue/view.scala.html
@@ -94,8 +94,7 @@
 		}
 		</p>
 
-        <button type="button"
-            class="btn small white @if(issue.getWatchers.contains(UserApp.currentUser())) { active } else { inactive }" data-toggle="button" id="watch-button"> @Messages("notification.watch") </button>
+        <button id="watch-button" type="button" class="nbtn medium blue @if(issue.getWatchers.contains(UserApp.currentUser())) { active }" data-toggle="button">@Messages("notification.watch")</button>
 
         @if(isAllowed(UserApp.currentUser(), issue.asResource(), Operation.DELETE)) {
         <a href="#deleteConfirm" data-toggle="modal" class="nbtn medium red">@Messages("button.delete")</a>

--- a/app/views/prjmenu.scala.html
+++ b/app/views/prjmenu.scala.html
@@ -29,11 +29,11 @@
                 <div class="btn-group dbtn-group">
                     @if(User.isWatching(project)){
                     <a href="@routes.WatchProjectApp.unwatch(project.owner, project.name)" class="nbtn medium blue last watchBtn">
-                        <i class="icon-eye-open icon-large"></i>
+                        <i class="icon-eye-open icon-large"></i> @Messages("notification.watch")
                     </a>
                     } else {
                     <a href="@routes.WatchProjectApp.watch(project.owner, project.name)" class="nbtn medium white last watchBtn">
-                        <i class="icon-eye-open icon-large"></i>
+                        <i class="icon-eye-open icon-large"></i> @Messages("notification.watch")
                     </a>
                     }
                     <button class="btn dropdown-toggle small" data-toggle="dropdown" style="padding:0">
@@ -155,7 +155,7 @@
                 }
                 <li class="sp-line">|</li>
                 <li @isActiveMenu(MenuType.ISSUE)>
-                    <a href="@routes.IssueApp.issues(project.owner, project.name, "all")" class="menu-item">
+                    <a href="@routes.IssueApp.issues(project.owner, project.name, "open")" class="menu-item">
                         <i class="icon-large icon-exclamation-sign"></i>
                         <span class="menu-title">@Messages("menu.issue")</span>
                         @if(Issue.countIssues(project.id, State.OPEN) > 0){
@@ -203,7 +203,7 @@ $(document).ready(function(){
         "H": "@routes.ProjectApp.project(project.owner, project.name)",
         "B": "@routes.BoardApp.posts(project.owner, project.name)",
         "C": "@routes.CodeApp.codeBrowser(project.owner, project.name)",
-        "I": "@routes.IssueApp.issues(project.owner, project.name,"all")",
+        "I": "@routes.IssueApp.issues(project.owner, project.name,"open")",
         "M": "@routes.MilestoneApp.milestones(project.owner, project.name)"
         @if(project.vcs.equals("GIT")){
            ,"F": "@getPullRequestURL(project)"

--- a/app/views/user/info.scala.html
+++ b/app/views/user/info.scala.html
@@ -38,8 +38,7 @@
                 }
             </div>
 
-            <ul class="nav nav-list project-category">
-                <li class="nav-header categotry-header">@Messages("project.group")</li>
+            <ul class="unstyled lst-stacked" style="margin-top:20px;">
                 <li @if(groupNames.contains("own")){class="active"}>
                 <a href="@routes.UserApp.userInfo(user.loginId, "own")">@Messages("project.createdByMe")</a>
                 </li>
@@ -69,9 +68,6 @@
             }
 
             <ul class="nav nav-tabs">
-                <li class="days-ago">
-                    @Messages("daysAgo.prefix")<input id="daysAgoBtn" name="daysAgo" type="number" min="1" max="99" class="input-mini-min" value="@daysAgo">@Messages("daysAgo.suffix")
-                </li>
                 <li @if(selected == "projects"){ class="active"} >
                     <a href="#projects" data-toggle="tab">
                         @Messages("projects") @showBadgeNumberIfExist(projects.size)
@@ -99,6 +95,10 @@
                 </li>
             </ul>
 
+            <div class="right-txt">
+                @Messages("daysAgo.prefix")<input id="daysAgoBtn" name="daysAgo" type="number" min="1" max="99" class="input-mini-min" value="@daysAgo">@Messages("daysAgo.suffix")
+            </div>
+            
             <div class="tab-content">
                 <div id="projects" class="tab-pane active">
                     @if(projects.size==0){

--- a/app/views/user/partial_issues.scala.html
+++ b/app/views/user/partial_issues.scala.html
@@ -21,13 +21,11 @@
 
 <div class="row-fluid issue-item">
     <div class="span10">
-        <div class="pull-left span1" style="margin-right: 10px;">
-            <a href="@routes.ProjectApp.project(project.owner, project.name)">
-                <img src="@projectLogoImage" alt="@project.owner / @project.name" class="img-rounded" />
-            </a>
-        </div>
         <div class="pull-left">
-            <a href="@routes.UserApp.userInfo(issue.authorLoginId)" class="avatar-wrap img-rounded">
+            <a href="@routes.ProjectApp.project(project.owner, project.name)" class="avatar-wrap mlarge nm">
+                <img src="@projectLogoImage" alt="@project.owner / @project.name">
+            </a>
+            <a href="@routes.UserApp.userInfo(issue.authorLoginId)" class="avatar-wrap mlarge">
                 <img src="@User.findByLoginId(issue.authorLoginId).avatarUrl" alt="@issue.authorName">
             </a>
         </div>

--- a/app/views/user/partial_milestones.scala.html
+++ b/app/views/user/partial_milestones.scala.html
@@ -21,11 +21,13 @@
 }
 
 <li class="milestone">
+    <div class="pull-left">
+        <a href="@routes.ProjectApp.project(project.owner, project.name)" class="avatar-wrap large" style="margin:8px 8px 0 0;">
+            <img src="@projectLogoImage">
+        </a>
+    </div>
     <div class="infos">
         <div class="meta-info">
-            <a href="@routes.ProjectApp.project(project.owner, project.name)">
-                <img src="@projectLogoImage" class="logo img-rounded span2" style="margin-right: 10px;" />
-            </a>
             <a href="@routes.MilestoneApp.milestone(project.owner, project.name, milestone.id)" class="title">@milestone.title</a>
             @if(milestone.dueDate != null) {
             <span class="sp">|</span>

--- a/app/views/user/partial_postings.scala.html
+++ b/app/views/user/partial_postings.scala.html
@@ -12,18 +12,17 @@
     }
 }
 
-<li class="board">
-    <div class="pull-left" style="margin-right: 10px;">
-        <a href="@routes.ProjectApp.project(project.owner, project.name)">
-            <img src="@projectLogoImage" alt="@project.owner / @project.name" class="img-rounded span1" />
+<li class="board" style="padding:10px 0;">
+    <div class="pull-left">
+        <a href="@routes.ProjectApp.project(project.owner, project.name)" class="avatar-wrap mlarge">
+            <img src="@projectLogoImage" alt="@project.owner / @project.name"/>
         </a>
-    </div>
-    <div class="author-avatar-space">
-        <a href="@routes.UserApp.userInfo(post.authorLoginId)" class="avatar-wrap img-rounded">
+        <a href="@routes.UserApp.userInfo(post.authorLoginId)" class="avatar-wrap mlarge">
             <img src="@User.findByLoginId(post.authorLoginId).avatarUrl" alt="@post.authorName">
         </a>
     </div>
-    <div class="contents">
+
+    <div class="contents" style="padding-left:10px;">
         <p class="title">
             <a href="@routes.BoardApp.post(project.owner, project.name, post.getNumber)">
                 @if(post.notice == true){<span class="label label-notice">@Messages("post.notice")</span>&nbsp;}

--- a/app/views/user/partial_projectlist.scala.html
+++ b/app/views/user/partial_projectlist.scala.html
@@ -14,9 +14,9 @@
 
 <li class="project">
     <div class="info-wrap">
-        <div class="pull-left span2">
-            <a href="@routes.ProjectApp.project(project.owner, project.name)">
-                <img src="@projectLogoImage" class="logo img-rounded" />
+        <div class="pull-left">
+            <a href="@routes.ProjectApp.project(project.owner, project.name)" class="avatar-wrap large">
+                <img src="@projectLogoImage">
             </a>
         </div>
         <div class="pull-left" style="margin-left: 10px;">
@@ -57,26 +57,33 @@
                 }
             }
             </ul>
-            <span>
-                @Html(Messages("project.onmember", User.findUsersByProject(project.id).length))
-                <i class="icon-star icon-middle"></i> @Html(Messages("project.onwatching", project.watchingCount))
-                <br/>
+        </div>
+        
+        <div class="stats">
+            @Html(Messages("project.onmember", User.findUsersByProject(project.id).length))<br/>
+            
             @if(user.loginId != project.owner && user.loginId == session.get("loginId") ){
-		        <a href="@routes.UserApp.leave(project.owner, project.name)" data-projectName="@project.name" class="nbtn black small last leaveProject"><i class="ico ico-delete-small"></i>@Messages("userinfo.leaveProject")</a>
+	        <a href="@routes.UserApp.leave(project.owner, project.name)" data-projectName="@project.name" class="nbtn black medium leaveProject">
+	            <i class="ico ico-delete-small"></i>@Messages("userinfo.leaveProject")
+            </a>
             }
-                @if(session.get("loginId") != project.owner ){
-                    @if(User.isWatching(project)){
-                        <span data-toggle="tooltip" title="unwatch" data-placement="right">
-                            <a href="@routes.WatchProjectApp.unwatch(project.owner, project.name)" class="watchBtn nbtn small last"><i class="icon-star icon-middle icon-white"></i></a>
-                        </span>
-                    }
-                    @if(!User.isWatching(project) && project.isPublic) {
-                        <span data-toggle="tooltip" title="watch" data-placement="right">
-                            <a href="@routes.WatchProjectApp.watch(project.owner, project.name)" class="watchBtn nbtn  purple small last "><i class="icon-star-empty icon-middle icon-white"></i></a>
-                        </span>
-                    }
+            
+            @if(session.get("loginId") != project.owner ){
+                @if(User.isWatching(project)){
+                    <a href="@routes.WatchProjectApp.unwatch(project.owner, project.name)" class="nbtn blue last medium watchBtn">
+                        <i class="icon-eye-open icon-middle icon-white"></i>
+                        @Messages("notification.watch")
+                        <span class="num-badge">@project.watchingCount</span>
+                    </a>
                 }
-            </span>
+                @if(!User.isWatching(project) && project.isPublic) {
+                    <a href="@routes.WatchProjectApp.watch(project.owner, project.name)" class="nbtn last medium watchBtn">
+                        <i class="icon-eye-close icon-middle icon-white"></i>
+                        @Messages("notification.watch")
+                        <span class="num-badge">@project.watchingCount</span>
+                    </a>
+                }
+            }
         </div>
     </div>
 </li>

--- a/app/views/usermenu.scala.html
+++ b/app/views/usermenu.scala.html
@@ -4,7 +4,6 @@
 @if(session.contains("loginId")){
     @if(project != null){
     <div class="member-role">
-        <i class="icon-user icon-large"></i>
         @Messages("role." + ProjectUser.roleOf(session.get("loginId"), project))
     </div>
     }

--- a/public/javascripts/service/yobi.board.View.js
+++ b/public/javascripts/service/yobi.board.View.js
@@ -54,13 +54,15 @@
          */
         function _attachEvent(){
             htElement.welBtnWatch.click(function(weEvt) {
-                var bWatched = $(weEvt.target).hasClass('active');
+                var welTarget = $(weEvt.target);
+                var bWatched = welTarget.hasClass("active");
 
-                if (!bWatched) {
-                    $yobi.sendForm({ "sURL" : htVar.sWatchUrl });
-                } else {
-                    $yobi.sendForm({ "sURL" : htVar.sUnwatchUrl });
-                }
+                $yobi.sendForm({
+                    "sURL": bWatched ? htVar.sUnwatchUrl : htVar.sWatchUrl,
+                    "fOnLoad": function(){
+                        welTarget.toggleClass("active");
+                    }
+                });
             });
         }
 

--- a/public/javascripts/service/yobi.issue.View.js
+++ b/public/javascripts/service/yobi.issue.View.js
@@ -56,13 +56,15 @@
          */
         function _attachEvent(){
             htElement.welBtnWatch.click(function(weEvt) {
-                var bWatched = $(weEvt.target).hasClass('active');
+                var welTarget = $(weEvt.target);
+                var bWatched = welTarget.hasClass("active");
 
-                if (!bWatched) {
-                    $yobi.sendForm({ "sURL" : htVar.sWatchUrl });
-                } else {
-                    $yobi.sendForm({ "sURL" : htVar.sUnwatchUrl });
-                }
+                $yobi.sendForm({
+                    "sURL": bWatched ? htVar.sUnwatchUrl : htVar.sWatchUrl,
+                    "fOnLoad": function(){
+                        welTarget.toggleClass("active");
+                    }
+                });
             });
         }
 


### PR DESCRIPTION
- .nbtn 버튼 우하단의 그림자(box-shadow) 제거. 버튼이 좀 더 납작해졌습니다.
  - 버튼 스타일은 이후로도 조금씩 수정 예정
- 이슈 목록
  - [전체] 탭 제거: 전체 이슈 링크와 중복되는 정보
  - [전체 이슈, 나에게 할당된 이슈, 내가 작성한 이슈] 버튼을 링크 스타일로 수정하고 상세검색 근처로 다시 이동
  - [상세검색] 토글 버튼 스타일 수정
- 사용자 페이지
  - 프로젝트 종류 링크의 스타일 수정
  - 목록의 항목별 스타일 수정
  - 프로젝트 로고, 아바타 표시 방법 통일 (프로젝트 로고를 목록에서 표시할 때 우선 avatar-wrap 사용)
- 게시판/이슈 읽기 페이지
  - [지켜보기] 버튼의 위치를 액션 버튼 옆으로 통일하고 .nbtn 스타일 적용. 클릭시 활성화 여부 즉시 반영하도록 수정
