### PR TITLE
Fix #414  -  add toolip for assignee infomation  on issue list

### DIFF
--- a/app/views/issue/partial_list.scala.html
+++ b/app/views/issue/partial_list.scala.html
@@ -60,7 +60,7 @@
     <div class="span2">
 	    <div class="empty-avatar-space pull-right">
 	        @if(issue.assigneeName != null) {
-	            <a href="@routes.UserApp.userInfo(issue.assignee.user.loginId)" class="avatar-wrap img-rounded">
+	            <a href="@routes.UserApp.userInfo(issue.assignee.user.loginId)" class="avatar-wrap img-rounded " data-toggle="tooltip" data-placement="top" title="@Messages("issue.assignee") @issue.assigneeName">
 	                <img src="@issue.assignee.user.avatarUrl" width="32" height="32" alt="@issue.assigneeName">
 	            </a>
 	        } else {
@@ -92,5 +92,7 @@
 		    "sIssueCheckBoxesSelector": "[type=checkbox][name=checked-issue]",
 		    "nTotalPages" : @totalPageCount
 	    });
+
+        $('.empty-avatar-space').tooltip({selector : 'a'});
     });
 </script>


### PR DESCRIPTION
## avatar 를 등록하지 않은 담당자를 쉽게 알아보기 위한 tooltip 추가
- tooltip  추가
- 현재 노출방향 : top (이미지 상단) 
## issue
- 이미지 왼쪽으로 표시 하기는 tooltip position 이 애매하게 생성되고 있어 일단 상단으로 추가 하였습니다.
- 왼쪽 정렬이 더 좋다는 의견이 많은 경우 해당 부분을 좀더 확인해 봐야 할듯 합니다. 
