### PR TITLE
change link color(RGB4183c4) on README area

### DIFF
--- a/app/assets/stylesheets/less/_page.less
+++ b/app/assets/stylesheets/less/_page.less
@@ -1908,6 +1908,21 @@
             display:none;
             padding: 25px;
             font-size: 14px;
+
+            a {
+                color:#4183c4;
+                text-decoration:none;
+            }
+
+            a:hover {
+                color:#4183c4;
+                text-decoration:underline;
+            }
+
+            a:active {
+                color:#4183c4;
+                text-decoration:none;
+            }
         }
     }
 }


### PR DESCRIPTION
## README View 영역의 링크 색상을 눈에 잘 띄고 일반적으로 링크임을 인지할수 있는 blue 계열로 변경하였습니다.

![screen shot 2013-08-01 at 3 39 24](https://f.cloud.github.com/assets/1558742/892065/514719c2-fa75-11e2-81f3-9d10aca416c6.png)
