### PR TITLE
modify marked converter for heading tag randering

### DIFF
--- a/public/javascripts/lib/marked.js
+++ b/public/javascripts/lib/marked.js
@@ -17,7 +17,7 @@ var block = {
   hr: /^( *[-*_]){3,} *(?:\n+|$)/,
   heading: /^ *(#{1,6}) *([^\n]+?) *#* *(?:\n+|$)/,
   nptable: noop,
-  lheading: /^([^\n]+)\n *(=|-){3,} *\n*/,
+  lheading: /^([^\n]+)\n *(=|-){2,} *\n*/,
   blockquote: /^( *>[^\n]+(\n[^\n]+)*\n*)+/,
   list: /^( *)(bull) [\s\S]+?(?:hr|\n{2,}(?! )(?!\1bull )\n*|\s*$)/,
   html: /^ *(?:comment|closed|closing) *(?:\n{2,}|\s*$)/,


### PR DESCRIPTION
# marked 컨버터의 heading 관련 syntax 수정
- `---` 와 `===` 만 허용하던 부분을 `--`, `==` 부터 적용되게 수정
- marked.js 수정으로 인하여 internal fork 가 되어 해당 부분은 marked.js project에 pull request 요청하여 origin project 에도 적용되게 할 예정 입니다. 
## 테스트 문법

```
[[한국어]](#korean)
Yobi
=======
[![Build Status](https://travis-ci.org/nforge/yobi.png?branch=master)](https://travis-ci.org/nforge/yobi)



Yobi, collaborative SW development platform.<br/>(Currently, unversioned - work in progress)


What is Yobi?
--

Yobi, a brand new version of nFORGE, is a web-based collaborative platform for software development.
Yobi offers many features to increase productivity and quality of your software: a bug tracker to manage bugs and issues, a wiki to share documents, a configuration management tool to control software version and so on.


## Installation

### check java version

    java -version

Required minimum java version is 7(1.7)

```
## 이전 랜더링 화면

![screen shot 2013-08-02 at 12 47 23](https://f.cloud.github.com/assets/1558742/898882/827c3ab6-fb26-11e2-8b69-76f4388ab595.png)
# 적용 후 화면

![screen shot 2013-08-02 at 12 47 23](https://f.cloud.github.com/assets/1558742/898883/8b0ce842-fb26-11e2-94a9-b32d71939d95.png)

마크다운 렌더링에 따른 스타일 적용은 별도의 이슈에서 처리할예정입니다. 
