### PR TITLE
Fix #444 Add default branch feature

### DIFF
--- a/app/controllers/CodeApp.java
+++ b/app/controllers/CodeApp.java
@@ -59,7 +59,8 @@ public class CodeApp extends Controller {
             }
         }
 
-        return redirect(routes.CodeApp.codeBrowserWithBranch(userName, projectName, "HEAD", ""));
+        String branch = project.defaultBranch == null ? "HEAD" : project.defaultBranch;
+        return redirect(routes.CodeApp.codeBrowserWithBranch(userName, projectName, branch, ""));
     }
 
     /**

--- a/app/controllers/ProjectApp.java
+++ b/app/controllers/ProjectApp.java
@@ -154,7 +154,7 @@ public class ProjectApp extends Controller {
      * @param projectName
      * @return 프로젝트 정보
      */
-    public static Result settingForm(String loginId, String projectName) {
+    public static Result settingForm(String loginId, String projectName) throws Exception {
         Project project = Project.findByOwnerAndProjectName(loginId, projectName);
 
         if (project == null) {
@@ -166,7 +166,8 @@ public class ProjectApp extends Controller {
         }
 
         Form<Project> projectForm = form(Project.class).fill(project);
-        return ok(setting.render("title.projectSetting", projectForm, project));
+        PlayRepository repository = RepositoryService.getRepository(project);
+        return ok(setting.render("title.projectSetting", projectForm, project, repository.getBranches()));
     }
 
     /**
@@ -252,13 +253,13 @@ public class ProjectApp extends Controller {
             }
         }
 
-        if (filledUpdatedProjectForm.hasErrors()) {
-            return badRequest(setting.render("title.projectSetting",
-                    filledUpdatedProjectForm, Project.find.byId(updatedProject.id)));
-        }
-
         Project project = Project.find.byId(updatedProject.id);
         PlayRepository repository = RepositoryService.getRepository(project);
+
+        if (filledUpdatedProjectForm.hasErrors()) {
+            return badRequest(setting.render("title.projectSetting",
+                    filledUpdatedProjectForm, Project.find.byId(updatedProject.id), repository.getBranches()));
+        }
 
         if (!repository.renameTo(updatedProject.name)) {
             throw new FileOperationException("fail repository rename to " + project.owner + "/" + updatedProject.name);

--- a/app/playRepository/GitRepository.java
+++ b/app/playRepository/GitRepository.java
@@ -461,6 +461,9 @@ public class GitRepository implements PlayRepository {
      */
     @Override
     public byte[] getRawFile(String revision, String path) throws IOException {
+        if (revision == null) {
+            revision = Constants.HEAD;
+        }
         RevTree tree = new RevWalk(repository).parseTree(repository.resolve(revision));
         TreeWalk treeWalk = TreeWalk.forPath(repository, path, tree);
         if (treeWalk.isSubtree()) {

--- a/app/views/project/setting.scala.html
+++ b/app/views/project/setting.scala.html
@@ -1,4 +1,4 @@
-@(message: String)(projectForm: Form[Project], project:Project)
+@(message: String)(projectForm: Form[Project], project: Project, branches: List[String])
 
 @import helper._
 @import utils.TemplateHelper._
@@ -48,6 +48,25 @@
                 <dd>
                     <input id="project-name" type="text" name="name" maxlength="250" value="@project.name">
                     <!-- @inputText(projectForm("name"), 'class->"text", 'maxlength -> "250") -->
+                </dd>
+
+                <dt>
+                    <label for="project-default-branch">@Messages("project.defaultBranch.placeholder")</label>
+                </dt>
+                <dd>
+                    <div data-id="project-default-branch" id="branches" class="btn-group branches" data-name="defaultBranch">
+                        <button class="btn dropdown-toggle large" data-toggle="dropdown">
+                            <span class="d-label">@project.defaultBranch</span>
+                            <span class="d-caret"><span class="caret"></span></span>
+                        </button>
+                        <ul class="dropdown-menu">
+                        @for(branch <- branches if branchItemType(branch) == "branch"){
+                            @defining(branchItemName(branch)){ branchName =>
+                                <li data-value="@branchName"><a>@Html(branchName)</a></li>
+                            }
+                        }
+                        </ul>
+                    </div>
                 </dd>
 
                 <dt>

--- a/conf/evolutions/default/48.sql
+++ b/conf/evolutions/default/48.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+
+ALTER TABLE project ADD COLUMN default_branch varchar(255);
+
+# --- !Downs
+
+ALTER TABLE project DROP COLUMN default_branch;

--- a/conf/messages
+++ b/conf/messages
@@ -350,6 +350,7 @@ project.created = Created
 project.createdByMe = Create
 project.default.group.member = Member
 project.default.group.watching = Watching
+project.defaultBranch.placeholder = Input default branch
 project.delete = Delete project
 project.delete.accept = I agree with deleting this project.
 project.delete.alert = You should agree with deleting this project.

--- a/conf/messages.ja
+++ b/conf/messages.ja
@@ -349,6 +349,7 @@ project.created = 作成日
 project.createdByMe = 作成したプロジェクト
 project.default.group.member = 参加しているプロジェクト
 project.default.group.watching = 見守っているプロジェクト
+project.defaultBranch.placeholder = ブランチの名前を入力してください
 project.delete = プロジェクト削除
 project.delete.accept = プロジェクトを削除する事に同意します
 project.delete.alert = 「プロジェクト削除する事に同意」にチェックしてください

--- a/conf/messages.ko
+++ b/conf/messages.ko
@@ -351,6 +351,7 @@ project.created = 생성일
 project.createdByMe = 만든 프로젝트
 project.default.group.member = 멤버로 참여중인 프로젝트
 project.default.group.watching = 지켜보는 프로젝트
+project.defaultBranch.placeholder = 기본 브랜치를 입력해주세요.
 project.delete = 프로젝트 삭제
 project.delete.accept = 프로젝트를 삭제하는데 동의합니다.
 project.delete.alert = 프로젝트 삭제에 동의하여야 합니다.


### PR DESCRIPTION
현재의 Yobi
- README.md를 보는 영역(홈)과 코드 영역이 서로 분리되어있어서 다른 브랜치의 README.md를 볼 수 없다.
- 기본 브랜치를 설정할 수 있는 기능이 없다.

현재 코드를 작성해 본 것은 기본 브랜치를 설정하고 그 브랜치의 README.md를 볼 수 있도록 하는 기능인데 코드와 홈의 영역이 분리되어있다. 그렇다고 브랜치를 돌려가면서 README.md 보여주는 기능을 홈에 붙이는 것도 조금 아리까리.

Play를 안해봐서 재미삼아 해봤어요. 리뷰해주세요. 외부인이 feature를 건들어도 되나 모르겠지만 말이죠. 언제가 될진 모르겠지만 미래에 요비를 도입해서 쓸 개발자입니다.

**프로젝트 세팅 화면**
![screen shot 2013-11-10 at 10 26 16 pm](https://f.cloud.github.com/assets/383192/1508612/667ea220-4a0b-11e3-9bc0-0ebff087909c.png)

**기본 브랜치 변경하기 전 프로젝트 홈 화면**
![screen shot 2013-11-10 at 10 27 55 pm](https://f.cloud.github.com/assets/383192/1508615/a897667e-4a0b-11e3-8248-109bd8800bd4.png)

**기본 브랜치 변경한 후 프로젝트 홈 화면**
![screen shot 2013-11-10 at 10 28 18 pm](https://f.cloud.github.com/assets/383192/1508614/a896685a-4a0b-11e3-9c68-1c1950536839.png)

**기본 브랜치를 변경한 후 코드 화면**
![screen shot 2013-11-10 at 10 36 21 pm](https://f.cloud.github.com/assets/383192/1508634/c6f386e2-4a0c-11e3-898b-b34f021bab53.png)
