### PR TITLE
코드 히스토리에서 발생하는 ArrayIndexOutOfBoundException 에러 처리

### DIFF
--- a/app/playRepository/SvnCommit.java
+++ b/app/playRepository/SvnCommit.java
@@ -40,11 +40,12 @@ public class SvnCommit extends Commit {
 
     @Override
     public String getShortMessage() {
-        String message = entry.getMessage();
-        if(message != null && !message.trim().isEmpty() && message.contains("\n")) {
-            return message.split("\n")[0];
+        String message = getMessage();
+        if (message != null && !message.isEmpty()) {
+            String[] lines = message.trim().split("\n");
+            return lines.length > 0 ? lines[0] : "";
         } else {
-            return message;
+            return "";
         }
     }
 

--- a/app/views/code/history.scala.html
+++ b/app/views/code/history.scala.html
@@ -130,8 +130,11 @@
                                 }
 
                                 @defining(commit.getMessage()){ commitMsg =>
-                                    <a href="@showCommitURL">@commitMsg.split("\n")(0)</a>
-
+                                    @if(commit.getShortMessage()) {
+                                        <a href="@showCommitURL">@commit.getShortMessage()</a>
+                                    } else {
+                                        <a href="@showCommitURL">@Messages("code.commitMsg.empty")</a>
+                                    }
                                     @if(commitMsg.split("\n").length > 1){
                                         <button type="button" class="more">&hellip;</button>
                                         <pre class="hidden">@commitMsg.replace(commitMsg.split("\n")(0)+"\n", "")</pre>

--- a/conf/messages
+++ b/conf/messages
@@ -70,6 +70,7 @@ code.author = Author
 code.closeCommentBox = Close Comment Box
 code.commitDate = Commit Date
 code.commitMsg = Commit Message
+code.commitMsg.empty = No commit message
 code.commits = Commits
 code.copyUrl = Copy URL
 code.filename = Filename

--- a/conf/messages.ja
+++ b/conf/messages.ja
@@ -70,6 +70,7 @@ code.author = 作成者
 code.closeCommentBox = コメント閉じる
 code.commitDate = コミット日時
 code.commitMsg = コミットメッセージ
+code.commitMsg.empty = No commit message
 code.commits = コミット
 code.copyUrl = URLコピー
 code.filename = ファイル名

--- a/conf/messages.ko
+++ b/conf/messages.ko
@@ -70,6 +70,7 @@ code.author = 작성자
 code.closeCommentBox = 댓글창 닫기
 code.commitDate = 커밋한 날짜
 code.commitMsg = 커밋 메시지
+code.commitMsg.empty = No commit message
 code.commits = 커밋
 code.copyUrl = 주소 복사
 code.filename = 파일명


### PR DESCRIPTION
split 함수 예외처리. split 첫번째 인자와 같은 값인 경우에는 array length 가 0이될 수 있는 문제 수정.

그외에 커밋 메세지가 비어있을 때 Messages("code.commitMsg.empty") 처리
#524 연관
