### PR TITLE
Fork 할 때 공개설정이 한글로 표현되는 문제

### DIFF
--- a/app/views/git/fork.scala.html
+++ b/app/views/git/fork.scala.html
@@ -52,8 +52,8 @@
                 <div class="control-group">
                     <label class="control-label">@Messages("project.shareOption")</label>
                     <div class="controls">
-                        <input name="isPublic" type="radio" checked="checked" id="public" value="true" class="radio-btn"><label for="public" class="bg-radiobtn label-public">공개</label>
-                        <input name="isPublic" type="radio" id="private" value="false" class="radio-btn"><label for="private" class="bg-radiobtn label-private">비공개</label>
+                        <input name="isPublic" type="radio" checked="checked" id="public" value="true" class="radio-btn"><label for="public" class="bg-radiobtn label-public">@Messages("project.public")</label>
+                        <input name="isPublic" type="radio" id="private" value="false" class="radio-btn"><label for="private" class="bg-radiobtn label-private">@Messages("project.private")</label>
                         <span class="help-inline">@Messages("project.private.notice")</span>
                     </div>
                 </div>


### PR DESCRIPTION
공개 / 비공개 정보가 브라우져 언어설정과 다르게 한글로 고정됩니다.
