### PR TITLE
SVN에서 breadcrumb이 갱신되지 않는 문제 fix

### DIFF
--- a/public/javascripts/service/yobi.code.Browser.js
+++ b/public/javascripts/service/yobi.code.Browser.js
@@ -169,24 +169,25 @@
             
             var sTargetPath = document.location.hash.substr(1);
             var welList = $('[data-listpath="' + sTargetPath + '"]');
-            
+
+            var sCheckPath = "";
+            htVar.aPathQueue = [];
+            htVar.aWelList = [];
+
+            // Path 단위로 목록이 필요함
+            sTargetPath.split("/").forEach(function(sPath){
+                sCheckPath = (sCheckPath === "") ? sPath : (sCheckPath + "/" + sPath);
+                htVar.aPathQueue.push(sCheckPath);
+            });
+            _updateBreadcrumbs(htVar.aPathQueue);
+
             if(welList.length > 0){ // 이미 리스트를 붙인 상태라면
                 welList.toggle();   // 목록 표시 여부만 토글하고
                 _setCurrentPathBold(sTargetPath);
             } else {                // 없으면 새로 리스트 만들어서 붙임
-                var sCheckPath = "";
-                htVar.aPathQueue = [];
-                htVar.aWelList = [];
-                
-                // Path 단위로 목록이 필요함
-                sTargetPath.split("/").forEach(function(sPath){
-                    sCheckPath = (sCheckPath === "") ? sPath : (sCheckPath + "/" + sPath);
-                    htVar.aPathQueue.push(sCheckPath);
-                });
-                
-                _updateBreadcrumbs(htVar.aPathQueue);
                 _requestFolderList();
             }
+
         }
         
         /**


### PR DESCRIPTION
SVN의 프로젝트에서 코드탭에 보면 선택한 폴더에 맞게 브래드크럼이 나오고 있습니다.

저장소 구조에 대한 데이터를 가져오기 위해 ajax요청을 하고 있는데요.
중복 요청을 최소화 하기 위해 처음 가져왔을 때 리스트를 저장하는 구조를 가지고 있습니다.

발생한 문제는 ajax 요청 로직에 브래드크럼 갱신 함수인 _updateBreadcrumbs()가 포함되어 있어
처음 폴더를 클릭했을 때만 브래드크럼을 갱신하고 있었습니다.

이 문제를 해결하기 위해 프로그램 순서를 적절히 조절하여 pull-request를 보냅니다.
