### PR TITLE
improve help message

### DIFF
--- a/app/views/help/toc.scala.html
+++ b/app/views/help/toc.scala.html
@@ -9,19 +9,19 @@
 <div class="page-wrap-outer">
     <div class="page-wrap">
         <ul class="qas">
-			<li class="qa">
-				<div class="question-wrap">
-					<i class="yobicon-q q"></i>
-					<a href="#!/toggle" class="question">이 사이트에서 사용하는 협업 개발 플랫폼의 이름은 무엇인가요?</a>
-					<i class="ico icor"></i>
-				</div>
-				<div class="answer-wrap">
-					<i class="yobicon-a a"></i>
-					<div class="answer" style="width:100%">
-						이 플랫폼의 이름은 Yobi이며 '요비'라고 읽습니다.
-					</div>
-				</div>
-			</li>
+            <li class="qa">
+                <div class="question-wrap">
+                    <i class="yobicon-q q"></i>
+                    <a href="#!/toggle" class="question">이 사이트에서 사용하는 협업 개발 플랫폼의 이름은 무엇인가요?</a>
+                    <i class="ico icor"></i>
+                </div>
+                <div class="answer-wrap">
+                    <i class="yobicon-a a"></i>
+                    <div class="answer" style="width:100%">
+                        이 플랫폼의 이름은 Yobi이며 '요비'라고 읽습니다.
+                    </div>
+                </div>
+            </li>
             <li class="qa">
                 <div class="question-wrap">
                     <i class="yobicon-q q"></i>
@@ -45,23 +45,20 @@
                     <i class="yobicon-a a"></i>
                     <div class="answer" style="width:100%">
                         <p>
-							상단의 "새 프로젝트 시작"을 클릭한 후 필요한 정보를 입력하면 됩니다.
-							&nbsp;<br/>
-						</p>
+                            상단의 "새 프로젝트 시작"을 클릭한 후 필요한 정보를 입력하면 됩니다.<br/>
+                        </p>
                         <p>
                             공개설정에서 공개를 선택하면 해당 프로젝트의 구성원이 아닌
                             사용자도 해당 프로젝트를 둘러볼 수 있습니다. 구성원이 아닌 경우,
-							코드 저장소를 익명으로 접근하여 소스코드를 받아 갈 수는 있지만
+                            코드 저장소를 익명으로 접근하여 소스코드를 받아 갈 수는 있지만
                             수정한 소스코드를 올릴 수는 없습니다. 
-							공개설정에서 비공개를 선택하면 해당 프로젝트의 구성원이 아닌 사용자는
-							프로젝트를 둘러볼 수 없으며, 이름과 설명만 볼 수 있습니다.
-							&nbsp;<br/>
+                            공개설정에서 비공개를 선택하면 해당 프로젝트의 구성원이 아닌 사용자는
+                            프로젝트를 둘러볼 수 없으며, 이름과 설명만 볼 수 있습니다.<br/>
                         </p>
                         <p>
                             코드 저장소 방식은 현재 Git과 Subversion을 지원합니다.
                             이 두가지 방식은 전 세계적으로 널리 쓰이고 있으며
-                            충분한 신뢰성과 성능을 가지고 있습니다.
-							&nbsp;<br/>
+                            충분한 신뢰성과 성능을 가지고 있습니다.<br/>
                         </p>
                         <p>
                             위의 내용을 다 작성하셨다면 "프로젝트 생성" 버튼을 눌러
@@ -124,7 +121,7 @@
             <li class="qa">
                 <div class="question-wrap">
                     <i class="yobicon-q q"></i>
-					<a href="#!/toggle" class="question">Yobi의 버그를 발견했어요.</a>
+                    <a href="#!/toggle" class="question">Yobi의 버그를 발견했어요.</a>
                     <i class="ico icor"></i>
                 </div>
                 <div class="answer-wrap">

--- a/app/views/help/toc.scala.html
+++ b/app/views/help/toc.scala.html
@@ -9,45 +9,63 @@
 <div class="page-wrap-outer">
     <div class="page-wrap">
         <ul class="qas">
+			<li class="qa">
+				<div class="question-wrap">
+					<i class="yobicon-q q"></i>
+					<a href="#!/toggle" class="question">이 사이트에서 사용하는 협업 개발 플랫폼의 이름은 무엇인가요?</a>
+					<i class="ico icor"></i>
+				</div>
+				<div class="answer-wrap">
+					<i class="yobicon-a a"></i>
+					<div class="answer" style="width:100%">
+						이 플랫폼의 이름은 Yobi이며 '요비'라고 읽습니다.
+					</div>
+				</div>
+			</li>
             <li class="qa">
                 <div class="question-wrap">
                     <i class="yobicon-q q"></i>
-                    <a href="#!/toggle" class="question">@Messages("app.name")를 설치하고 싶어요.</a>
+                    <a href="#!/toggle" class="question">Yobi를 설치하고 싶어요.</a>
                     <i class="ico icor"></i>
                 </div>
                 <div class="answer-wrap">
                     <i class="yobicon-a a"></i>
                     <div class="answer" style="width:100%">
-                        @Messages("app.name")를 설치하고자 하면 <a href="http://github.com/nforge/yobi#korean">http://github.com/nforge/yobi#korean</a>를 참고해 주세요.
+                        Yobi를 설치하려면 <a href="http://github.com/nforge/yobi#korean">http://github.com/nforge/yobi#korean</a>를 참고해주세요.
                     </div>
                 </div>
             </li>
             <li class="qa">
                 <div class="question-wrap">
                     <i class="yobicon-q q"></i>
-                    <a href="#!/toggle" class="question">프로젝트를 새로 생성하고 싶어요.</a>
+                    <a href="#!/toggle" class="question">프로젝트를 새로 만들고 싶어요.</a>
                     <i class="ico icor"></i>
                 </div>
                 <div class="answer-wrap">
                     <i class="yobicon-a a"></i>
                     <div class="answer" style="width:100%">
-                        <p>상단의 "새 프로젝트 시작"을 클릭하신후 필요한 정보를 입력하시면 됩니다.</p>
                         <p>
-                            공개설정에서 공개를 택하게 되면 해당 프로젝트의 멤버가 아닌
-                            사용자들도 해당 프로젝트를 둘러 볼 수 있게 되며 멤버가 아니라면
-                            코드 저장소를 익명으로 접근하여 소스코드를 받아 갈 수는 있지만
-                            소스코드를 수정하지는 못합니다. 공개설정에서 비공개를 선택하면
-                            해당 프로젝트의 멤버가 아닌 사용자들은 단지 설명과
-                            이름만을 볼수 있습니다.
+							상단의 "새 프로젝트 시작"을 클릭한 후 필요한 정보를 입력하면 됩니다.
+							&nbsp;<br/>
+						</p>
+                        <p>
+                            공개설정에서 공개를 선택하면 해당 프로젝트의 구성원이 아닌
+                            사용자도 해당 프로젝트를 둘러볼 수 있습니다. 구성원이 아닌 경우,
+							코드 저장소를 익명으로 접근하여 소스코드를 받아 갈 수는 있지만
+                            수정한 소스코드를 올릴 수는 없습니다. 
+							공개설정에서 비공개를 선택하면 해당 프로젝트의 구성원이 아닌 사용자는
+							프로젝트를 둘러볼 수 없으며, 이름과 설명만 볼 수 있습니다.
+							&nbsp;<br/>
                         </p>
                         <p>
                             코드 저장소 방식은 현재 Git과 Subversion을 지원합니다.
-                            Subversion과 Git은 전 세계적으로 널리 쓰이고 있으며
+                            이 두가지 방식은 전 세계적으로 널리 쓰이고 있으며
                             충분한 신뢰성과 성능을 가지고 있습니다.
+							&nbsp;<br/>
                         </p>
                         <p>
-                            위의 내용을 다 작성하셨다면 "프로젝트 생성" 버튼을 누르면
-                            새로운 프로젝트를 생성하실수 있습니다.
+                            위의 내용을 다 작성하셨다면 "프로젝트 생성" 버튼을 눌러
+                            새로운 프로젝트를 생성할 수 있습니다.
                         </p>
                     </div>
                 </div>
@@ -55,50 +73,50 @@
             <li class="qa">
                 <div class="question-wrap">
                     <i class="yobicon-q q"></i>
-                    <a href="#!/toggle" class="question">내가 참여하는 프로젝트들은 어디서 볼수 있나요?</a>
+                    <a href="#!/toggle" class="question">내가 참여하는 프로젝트들은 어디서 볼 수 있나요?</a>
                     <i class="ico icor"></i>
                 </div>
                 <div class="answer-wrap">
                     <i class="yobicon-a a"></i>
                     <div class="answer" style="width:100%">
                         <a href="/">메인화면</a>
-                        우측 하단에 다음과 같이 참여하고 있는 프로젝트의 목록을 볼수 있습니다.
-                        자물쇠가 있는 것은 비공개 프로젝트이며 자물쇠가 없는 것은 공개 프로젝트 입니다.
-                        혹은 자신의 <a href="/info">정보 페이지</a>에서도 확인하실수 있습니다.
+                        우측 하단을 보시면 참여하고 있는 프로젝트의 목록을 볼 수 있습니다.
+                        자물쇠 그림이 있는 항목은 비공개 프로젝트이며 자물쇠 그림이 없는 항목은 공개 프로젝트 입니다.
+                        여러분 자신의 <a href="/info">정보 페이지</a>에서도 확인할 수 있습니다.
                     </div>
                 </div>
             </li>
             <li class="qa">
                 <div class="question-wrap">
                     <i class="yobicon-q q"></i>
-                    <a href="#!/toggle" class="question">프로젝트 탈퇴는 어떻게 하나요.</a>
+                    <a href="#!/toggle" class="question">프로젝트 탈퇴는 어떻게 하나요?</a>
                     <i class="ico icor"></i>
                 </div>
                 <div class="answer-wrap">
                     <i class="yobicon-a a"></i>
                     <div class="answer" style="width:100%">
-                        자신의 <a href="/info">정보 페이지</a>에서 참여하고 있는 프로젝트 목록을 볼 수있고
-                        탈퇴도 할수 있습니다. 자신이 프로젝트의 유일한 관리자라면 해당 프로젝트에서 탈퇴를 할 수 없습니다.
+                        자신의 <a href="/info">정보 페이지</a>에서 참여하고 있는 프로젝트 목록을 볼 수 있고
+                        탈퇴도 할 수 있습니다. 자신이 프로젝트의 유일한 관리자라면 해당 프로젝트에서 탈퇴를 할 수 없습니다.
                     </div>
                 </div>
             </li>
             <li class="qa">
                 <div class="question-wrap">
                     <i class="yobicon-q q"></i>
-                    <a href="#!/toggle" class="question">게시판에서는 어떠한 것들을 할수 있나요?</a>
+                    <a href="#!/toggle" class="question">게시판에서 어떤 기능을 쓸 수 있나요?</a>
                     <i class="ico icor"></i>
                 </div>
                 <div class="answer-wrap">
                     <i class="yobicon-a a"></i>
                     <div class="answer" style="width:100%">
-                        게시판에서는 다음과 같은 기능이 가능합니다.
+                        게시판에서는 다음과 같은 기능을 쓸 수 있습니다.
                         <ul>
-                            <li>게시물 읽기: 사용자는 게시물의 내용을 볼 수 있다.</li>
-                            <li>게시물 댓글 등록: 로그인 유저는 게시물에 댓글을 남길 수 있다.</li>
-                            <li>게시물 댓글 조회: 사용자는 게시물의 댓글을 볼 수 있다.</li>
-                            <li>게시물 댓글 삭제: 로그인 유저는 자신이 남긴 댓글을 삭제할 수 있다.</li>
-                            <li>관리자 게시물 댓글 삭제: 프로젝트 관리자는 댓글을 삭제할 수 있다.</li>
-                            <li>관리자 게시물 수정: 프로젝트 관리자는 게시물을 편집/삭제 할 수 있다.</li>
+                            <li>게시물 읽기: 사용자는 게시물의 내용을 볼 수 있습니다.</li>
+                            <li>게시물 댓글 등록: 로그인 유저는 게시물에 댓글을 남길 수 있습니다.</li>
+                            <li>게시물 댓글 조회: 사용자는 게시물의 댓글을 볼 수 있습니다.</li>
+                            <li>게시물 댓글 삭제: 로그인 유저는 자신이 남긴 댓글을 삭제할 수 있습니다.</li>
+                            <li>관리자 게시물 댓글 삭제: 프로젝트 관리자는 댓글을 삭제할 수 있습니다.</li>
+                            <li>관리자 게시물 수정: 프로젝트 관리자는 게시물을 편집/삭제 할 수 있습니다.</li>
                         </ul>
                     </div>
                 </div>
@@ -106,14 +124,14 @@
             <li class="qa">
                 <div class="question-wrap">
                     <i class="yobicon-q q"></i>
-                    <a href="#!/toggle" class="question">@Messages("app.name")의 버그를 발견했어요.</a>
+					<a href="#!/toggle" class="question">Yobi의 버그를 발견했어요.</a>
                     <i class="ico icor"></i>
                 </div>
                 <div class="answer-wrap">
                     <i class="yobicon-a a"></i>
                     <div class="answer" style="width:100%">
-                        @Messages("app.name")는 현재 Open Source로 진행되고 있습니다. 버그를 발견하셨다면
-                        <a href="https://github.com/nforge/yobi/issues">@Messages("app.name") 이슈트래커에 등록</a>해 주시거나 패치를 만들어 보내주시면 됩니다.
+                        Yobi는 현재 Open Source로 진행중입니다. 버그를 발견하셨다면
+                        <a href="https://github.com/nforge/yobi/issues">Yobi 이슈트래커에 등록</a>해 주시거나 패치를 만들어 보내주시면 됩니다.
                     </div>
                 </div>
             </li>

--- a/app/views/help/toc.scala.html
+++ b/app/views/help/toc.scala.html
@@ -127,7 +127,7 @@
                 <div class="answer-wrap">
                     <i class="yobicon-a a"></i>
                     <div class="answer" style="width:100%">
-                        Yobi는 현재 Open Source로 진행중입니다. 버그를 발견하셨다면
+                        @Messages("app.name")의 플랫폼 Yobi는 현재 Open Source로 진행중입니다. 버그를 발견하셨다면
                         <a href="https://github.com/nforge/yobi/issues">Yobi 이슈트래커에 등록</a>해 주시거나 패치를 만들어 보내주시면 됩니다.
                     </div>
                 </div>

--- a/app/views/help/toc.scala.html
+++ b/app/views/help/toc.scala.html
@@ -121,7 +121,7 @@
             <li class="qa">
                 <div class="question-wrap">
                     <i class="yobicon-q q"></i>
-                    <a href="#!/toggle" class="question">Yobi의 버그를 발견했어요.</a>
+                    <a href="#!/toggle" class="question">@Messages("app.name")의 버그를 발견했어요.</a>
                     <i class="ico icor"></i>
                 </div>
                 <div class="answer-wrap">


### PR DESCRIPTION
도움말 메시지 개선 패치를 제안합니다.
1. Yobi 플랫폼 이름을 명확하게 언급하는 부분 처음 부분에 추가.
2. 이전 커밋에서 @Messages("app.name") 문자열을 코드에 그대로 사용하여 플랫폼의 이름이 올바르게 나타나지 않는 문제 수정.
3. 문장과 문단을 일부 다듬었습니다.
4. 일부 추상 표현(~하는 것)을 구체적인 단어/용어로 바꾸었습니다.
