### PR TITLE
replace a tag with location.href

### DIFF
--- a/app/assets/stylesheets/less/_page.less
+++ b/app/assets/stylesheets/less/_page.less
@@ -566,7 +566,7 @@
                 color: #2cb400;
             }
         }
-        
+
         .d2-program:hover {
             background-color:#5f5f5f;
             text-decoration:none;
@@ -2086,7 +2086,7 @@ label.inline-list {
                     &.over { color:#f36c22; }
                 }
             }
-            
+
             .progress-wrap {
                 overflow: hidden;
                 color: #999;
@@ -3008,7 +3008,7 @@ div.markdown-loader {
     min-height: 140px;
     padding: 15px 20px;
     text-align: left;
-    clear: both;    
+    clear: both;
 }
 
 div.markdown-preview {
@@ -3420,9 +3420,9 @@ label.issue-item-row {
                 text-decoration: none;
             }
 
-            &.name { 
+            &.name {
                 color : #333;
-                
+
                 &:hover {
                     color:#333;
                 }
@@ -3472,7 +3472,7 @@ label.issue-item-row {
                     &.item-icon {
                         background-color:#F7F7F7;
                         color:#3592b5;
-                        font-size: 9px; 
+                        font-size: 9px;
                         padding-top:2px;
                         line-height: 12px;
                         border-left:1px solid #EEE;
@@ -3480,7 +3480,7 @@ label.issue-item-row {
                         &:first-child {
                             border-left:none;
                         }
-                        
+
                         &.strong {
                             color:@primary;
                         }
@@ -3619,7 +3619,7 @@ label.issue-item-row {
             min-height:30px;
         }
 
-       
+
         .write-comment-box { padding:0; margin-top:20px; }
     }
 
@@ -4132,7 +4132,10 @@ label.issue-item-row {
     }
     .listitem {
         border-bottom:1px solid #efefef;
-        .filename { font-size:10pt; white-space:nowrap; .text-overflow; }
+        .filename {
+          font-size:10pt; white-space:nowrap; .text-overflow;
+          a { cursor:pointer;}
+        }
         .commitMsg { font-size:10pt; color:#7e7e7e; .text-overflow; }
         .commitDate { font-size:8pt; color:#7e7e7e; white-space:nowrap; text-align:right; padding-right:5px; }
     }
@@ -5579,7 +5582,7 @@ div.diff-body[data-outdated="true"] tr:hover .icon-comment {
         text-decoration:none;
         background-color:#fafafa;
     }
-    
+
     &.open {
         .box-shadow(inset 5px 0px 0px @state-open);
     }
@@ -5761,7 +5764,7 @@ div.diff-body[data-outdated="true"] tr:hover .icon-comment {
         margin-top: 15px;
         font-weight: normal;
         padding:0 15px;
-        
+
         strong {
             color:#f36c22;
         }
@@ -5868,7 +5871,7 @@ div.diff-body[data-outdated="true"] tr:hover .icon-comment {
         margin-top:10px;
         font-size: 13px;
         color:#999;
-        padding-left:20px;  
+        padding-left:20px;
 
         &.np {
             padding-left:0 !important;
@@ -5886,7 +5889,7 @@ div.diff-body[data-outdated="true"] tr:hover .icon-comment {
         }
     }
 
-    .user-link { 
+    .user-link {
         color: #3592b5 !important;
         font-weight: bold;
     }

--- a/app/views/code/partial_view_folder.scala.html
+++ b/app/views/code/partial_view_folder.scala.html
@@ -28,7 +28,7 @@
     @defining(fieldText(file, "type")) { fileType =>
     <div id="cb-@listPath@fileName" class="row-fluid listitem" data-path="@getDataPath(listPath, fileName)">
         <div class="span6 filename">
-            <a href="@getCorrectedPath(filePath, fileName)@if(fileType.eq(" folder")){#cb-@listPath@fileName}"
+            <a onclick="location.href='@getCorrectedPath(filePath, fileName)@if(fileType.eq(" folder")){#cb-@listPath@fileName}'"
                 class="@getFileClass(file)" title="@fileName" @if(fileType.eq("folder")){data-type="folder"}
                 data-targetPath="@getDataPath(listPath, fileName)">
                 <span class="dynatree-icon vmiddle"></span>@fileName


### PR DESCRIPTION
When opened yobi site on Safari browser, If folder name is korean, a
link have character problem (but haven’t other browsers). so I replace
a tag with location.href

저장소에 **한글 디렉토리 명**이 있을 경우, **safari** 브라우저에서 `<a href=""/>` 링크로 되어 있는 디렉토리명을 클릭했을 때, 인코딩이 깨어지는 문제가 발생합니다. URL 자체에 한글을 포함해서 주소창에 넣으면 문제가 발생하지 않지만 a 링크를 클릭했을 때만 문제가 발생합니다. 그래서 a 링크로 되어 있는 코드를 `onclick="location.href='''"` 으로 변경했습니다. 변경후 safari 브라우저에서도 정상으로 동작합니다. 다른 브라우저도 이상 없이 동작합니다. 
