### PR TITLE
fix button align bug in milestone view

### DIFF
--- a/app/views/milestone/view.scala.html
+++ b/app/views/milestone/view.scala.html
@@ -62,7 +62,7 @@
                 <div class="attachments" data-resource-type="@ResourceType.MILESTONE" data-resource-id="@milestone.id"></div>
             </div>
 
-            <div class="actrow right-txt" style="padding: 15px 0; clear:both;">
+            <div class="actrow right-txt row-fluid" style="padding: 15px 0; clear:both;">
                 <a href="@routes.MilestoneApp.milestones(project.owner, project.name)" class="ybtn pull-left">@Messages("button.list")</a>
 
                 @if(isAllowed(UserApp.currentUser(), milestone.asResource(), Operation.DELETE)){


### PR DESCRIPTION
마일스톤 상세 페이지에서 삭제 / 수정 권한이 없을경우,
pull-left 때문에 목록 버튼이 밑으로 가면서 UI가 틀어지는 문제를 수정하였습니다.

적용전
![image](https://cloud.githubusercontent.com/assets/6916639/7100773/af938d1c-e06f-11e4-831d-9820bd996015.png)

적용후
![image](https://cloud.githubusercontent.com/assets/6916639/7100776/dbf82642-e06f-11e4-9f33-fbdcea3243a6.png)