### PR TITLE
Fixed typo of unzipped directory name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ or using web browser (for windows)
 
 #### Change directory to unzipped directory
 
-    cd typesafe-activator-1.2.10-minimal
+    cd activator-1.2.10-minimal
 
 #### Download Yobi
 
@@ -253,7 +253,7 @@ JDK 7(1.7) 혹은 8(1.8) 이어야 합니다.
 
 #### 압축을 푼 다음 하위 디렉터리로 이동
 
-    cd typesafe-activator-1.2.10-minimal
+    cd activator-1.2.10-minimal
 
 #### Yobi 소스 내려 받기
 


### PR DESCRIPTION
Resolves #890

next/README.md에서는 `http://downloads.typesafe.com/typesafe-activator/1.2.10/typesafe-activator-1.2.10-minimal.zip` 에서 minify된 typesafe 바이너리를 받아 오도록 안내하고 있는데, 해당 파일의 압축을 풀면 나오는 디렉토리 이름이 `typesafe-activator-1.2.10-minimal` 이 아닌 `activator-1.2.10-minimal` 인 것 같습니다.

해당 부분을 수정하여 PR을 보냅니다. 확인 부탁드리겠습니다. 감사합니다.