### PR TITLE
Fixed project.siteurl to be fit with route rule.

### DIFF
--- a/app/models/Project.java
+++ b/app/models/Project.java
@@ -143,7 +143,7 @@ public class Project extends Model implements LabelOwner {
      * @see {@link RoleType#SITEMANAGER}
      */
     public static Long create(Project newProject) {
-        newProject.siteurl = "http://localhost:9000/" + newProject.name;
+        newProject.siteurl = "http://localhost:9000/" + newProject.owner + "/" + newProject.name;
         newProject.createdDate = new Date();
         newProject.save();
         ProjectUser.assignRole(User.SITE_MANAGER_ID, newProject.id,

--- a/conf/test-data.yml
+++ b/conf/test-data.yml
@@ -56,7 +56,7 @@ projects:
         overview:       Yobi는 소프트웨어 개발에 필요한 기능들을 사용하기 편리하게 웹으로 묶은 협업 개발 플랫폼입니다.
         projectScope:   PUBLIC
         vcs:            GIT
-        siteurl:       http://localhost:9000/projectYobi
+        siteurl:       http://localhost:9000/yobi/projectYobi
         owner:          yobi
         createdDate:           2012-02-01 08:00:00
     - !!models.Project
@@ -64,7 +64,7 @@ projects:
         overview:       Yobi는 소프트웨어 개발에 필요한 기능들을 사용하기 편리하게 웹으로 묶은 협업 개발 플랫폼입니다.
         projectScope:   PUBLIC
         vcs:            GIT
-        siteurl:       http://localhost:9000/projectYobi-1
+        siteurl:       http://localhost:9000/yobi/projectYobi-1
         owner:          yobi
         createdDate:           2013-11-18 11:11:00
         originalProject:       !!models.Project
@@ -74,7 +74,7 @@ projects:
         overview:       Jindo는 NHN에서 제작한 Javascript Library 입니다.
         projectScope:   PRIVATE
         vcs:            Subversion
-        siteurl:       http://localhost:9000/Jindo
+        siteurl:       http://localhost:9000/laziel/Jindo
         owner:          laziel
         createdDate:           2012-01-01 08:00:00
     - !!models.Project
@@ -82,7 +82,7 @@ projects:
         overview:       CUBRID는 엔터프라이즈급 오픈 소스 DBMS로서, 인터넷 서비스에 최적화된 DBMS를 지향하고 있습니다.
         projectScope:   PRIVATE
         vcs:            GIT
-        siteurl:       http://localhost:9000/CUBRID
+        siteurl:       http://localhost:9000/doortts/CUBRID
         owner:          doortts
         createdDate:           2012-08-01 08:00:00
     - !!models.Project
@@ -90,7 +90,7 @@ projects:
         overview:       네이버 앱팩토리 플랫폼에서 제공하는 오픈소셜 API를 직접 실행해 볼 수 있는 애플리케이션입니다.
         projectScope:   PRIVATE
         vcs:            GIT
-        siteurl:       http://localhost:9000/HelloSocialApp
+        siteurl:       http://localhost:9000/yobi/HelloSocialApp
         owner:          yobi
         createdDate:           2012-12-01 08:00:00
     - !!models.Project
@@ -98,7 +98,7 @@ projects:
         overview:       네이버 앱팩토리 플랫폼에서 제공하는 오픈소셜 API를 직접 실행해 볼 수 있는 애플리케이션입니다.
         projectScope:   PRIVATE
         vcs:            GIT
-        siteurl:       http://localhost:9000/HelloSocialApp
+        siteurl:       http://localhost:9000/yobi/HelloSocialApp
         owner:          yobi
         createdDate:           2013-11-18 13:40:00
         originalProject:       !!models.Project
@@ -108,7 +108,7 @@ projects:
         overview:       테스트 애플리케이션
         projectScope:   PUBLIC
         vcs:            GIT
-        siteurl:       http://localhost:9000/Test
+        siteurl:       http://localhost:9000/yobi/Test
         owner:          yobi
         createdDate:           2012-12-01 08:00:00
 # PullRequests

--- a/test/models/ProjectTest.java
+++ b/test/models/ProjectTest.java
@@ -42,12 +42,13 @@ public class ProjectTest extends ModelTest<Project> {
 
         assertThat(actualProject).isNotNull();
         assertThat(actualProject.name).isEqualTo("prj_test");
-        assertThat(actualProject.siteurl).isEqualTo("http://localhost:9000/prj_test");
+        assertThat(actualProject.siteurl).isEqualTo("http://localhost:9000/yobi/prj_test");
     }
 
     private Project getNewProject() {
         Project project = new Project();
         project.name = "prj_test";
+        project.owner = "yobi";
         project.overview = "Overview for prj_test";
         project.projectScope = ProjectScope.PRIVATE;
         project.vcs = "GIT";
@@ -98,7 +99,7 @@ public class ProjectTest extends ModelTest<Project> {
         assertThat(project.overview).isEqualTo("Yobi는 소프트웨어 개발에 필요한 기능들을 사용하기 편리하게 웹으로 묶은 협업 개발 플랫폼입니다.");
         assertThat(project.projectScope).isEqualTo(ProjectScope.PUBLIC);
         assertThat(project.vcs).isEqualTo("GIT");
-        assertThat(project.siteurl).isEqualTo("http://localhost:9000/projectYobi");
+        assertThat(project.siteurl).isEqualTo("http://localhost:9000/yobi/projectYobi");
 
     }
 


### PR DESCRIPTION
project.siteurl에 project.owner가 포함되지 않은 값이 들어가 있어 현재의 route rule에 맞지 않는 것 같습니다.
`yobi` 라는 유저가 만든 project 이름이 `prj_test`라고 했을 때, 맞는 siteurl은 `http://localhost:9000/prj_test` 가 아닌 `http://localhost:9000/yobi/prj_test`인 것 같습니다. 실제로도 후자의 주소로 들어갔을 때 접속이 가능합니다.

확인 부탁드리겠습니다. 감사합니다.
